### PR TITLE
Use S3_UPLOAD_ENDPOINT for Next.js image remote patterns

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -26,9 +26,10 @@ if (process.env.S3_UPLOAD_ENDPOINT) {
     pattern.port = url.port
   }
 
-  // Include pathname pattern for local storage servers
-  if (url.pathname && url.pathname.includes('/knots')) {
-    pattern.pathname = '/knots/**'
+  // Include pathname pattern if specified (use wildcard to allow subpaths)
+  if (url.pathname && url.pathname !== '/') {
+    // Use the actual pathname from the URL, ensuring it ends with '/**'
+    pattern.pathname = `${url.pathname.replace(/\/$/, '')}/**`
   }
 
   remotePatterns.push(pattern)


### PR DESCRIPTION
Extract protocol, port, and pathname from S3_UPLOAD_ENDPOINT environment variable instead of hardcoding local storage server configuration. This allows images from the configured endpoint (e.g., http://192.168.5.94:9002/knots/...) to be loaded by Next.js Image component.