### PR TITLE
feat: Display app version in footer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:21-alpine AS base
 
+ARG APP_VERSION
+ENV NEXT_PUBLIC_APP_VERSION=${APP_VERSION}
+
 WORKDIR /usr/app
 COPY ./package.json \
      ./package-lock.json \

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
 KNOT_APP_NAME=$(node -p -e "require('./package.json').name")
-KNOT_VERSION=$(node -p -e "require('./package.json').version")
+PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
+
+# Try to get version from git tag (e.g., v1.19.4 -> 1.19.4)
+# Fall back to package.json version if git tag is not available
+if git describe --tags --exact-match HEAD 2>/dev/null | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+'; then
+  GIT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null)
+  # Remove 'v' prefix if present
+  KNOT_VERSION=$(echo "$GIT_TAG" | sed 's/^v//')
+else
+  KNOT_VERSION=$PACKAGE_VERSION
+fi
 
 # we need to set dummy data for POSTGRES env vars in order for build not to fail
 docker buildx build \
+    --build-arg APP_VERSION=${KNOT_VERSION} \
     -t ${KNOT_APP_NAME}:${KNOT_VERSION} \
     -t ${KNOT_APP_NAME}:latest \
     .

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { ApplePwaSplash } from '@/app/apple-pwa-splash'
+import { Footer } from '@/components/footer'
 import { LocaleSwitcher } from '@/components/locale-switcher'
 import { ProgressBar } from '@/components/progress-bar'
 import { ThemeProvider } from '@/components/theme-provider'
@@ -100,7 +101,10 @@ function Content({ children }: { children: React.ReactNode }) {
             </ul>
           </div>
         </header>
-        <div className="flex-1 flex flex-col">{children}</div>
+        <div className="flex flex-col h-full">
+          <div className="flex-1 flex flex-col overflow-y-auto">{children}</div>
+          <Footer />
+        </div>
         <Toaster />
       </TooltipProvider>
     </TRPCProvider>
@@ -117,7 +121,7 @@ export default async function RootLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       <ApplePwaSplash icon="/logo-with-text.png" color="#027756" />
-      <body className="mt-16 min-h-dvh flex flex-col items-stretch">
+      <body className="mt-16 h-[calc(100dvh-4rem)] flex flex-col items-stretch overflow-hidden">
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider
             attribute="class"

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,0 +1,13 @@
+import { env } from '@/lib/env'
+
+export function Footer() {
+  return (
+    <footer className="border-t border-border bg-background/50 backdrop-blur-xs">
+      <div className="container mx-auto px-4 py-4">
+        <div className="flex items-center justify-center text-sm text-muted-foreground">
+          <span>Version {env.NEXT_PUBLIC_APP_VERSION}</span>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -36,6 +36,7 @@ const envSchema = z
       z.boolean().default(false),
     ),
     OPENAI_API_KEY: z.string().optional(),
+    NEXT_PUBLIC_APP_VERSION: z.string().optional().default('dev'),
   })
   .superRefine((env, ctx) => {
     if (


### PR DESCRIPTION
## Summary
This PR adds the ability to display the app version in the footer of every page.

## Changes
- **Build script**: Extracts version from git tags (e.g., `v1.19.4`) during Docker build, with fallback to `package.json` version
- **Dockerfile**: Accepts `APP_VERSION` build arg and sets `NEXT_PUBLIC_APP_VERSION` environment variable
- **Environment schema**: Added `NEXT_PUBLIC_APP_VERSION` with default value `'dev'`
- **Footer component**: New component that displays the version using shadcn CSS variables
- **Layout**: Updated to include footer with proper flex layout to prevent unnecessary scrolling

## How it works
- When building from a git tag (e.g., `v1.19.4`), the version is extracted and displayed
- Falls back to `package.json` version if no git tag is found
- Displays `dev` in local development if neither is available