### PR TITLE
fix: remove [skip ci] from semantic-release and add manual workflow dispatch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g., v1.20.0)'
+        required: true
+        type: string
 
 jobs:
   build-and-push-image:
@@ -15,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Login to Github Container Registry
         uses: docker/login-action@v3

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,7 +14,7 @@
       "@semantic-release/git",
       {
         "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
## Summary
This PR fixes the issue where the CD workflow wasn't triggering after semantic-release created a new version.

## Changes
- **Remove [skip ci]**: Removed `[skip ci]` from semantic-release commit message so CD workflow can run
- **Add manual dispatch**: Added `workflow_dispatch` to CD workflow so it can be manually triggered if needed

## Why
The `[skip ci]` in the semantic-release commit message was preventing the CD workflow from running when tags were created. Now the CD workflow will properly trigger on tag pushes.