### PR TITLE
feat: BYO OpenAI endpoint support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,18 @@ NEXTAUTH_URL=http://localhost:3000
 # Email delivery (Resend) — seed users use delivered+*@resend.dev (see Resend test email docs)
 RESEND_API_KEY=re_your_resend_api_key
 EMAIL_FROM=onboarding@resend.dev
+
+# OpenAI / AI features (optional — enables receipt scanning and category auto-assignment)
+NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT=false
+NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT=false
+# API key for the OpenAI-compatible provider. Required when either AI feature flag above is enabled.
+OPENAI_API_KEY=sk-your-openai-api-key
+# Base URL for an OpenAI-compatible API endpoint (optional).
+# Omit to use the default OpenAI API (https://api.openai.com/v1).
+# Must be a valid http or https URL.
+# OPENAI_BASE_URL=http://localhost:11434/v1
+# Model identifier for chat completions (optional).
+# Applies to both receipt scanning and category extraction.
+# Omit to use built-in defaults (gpt-4-turbo for receipts, gpt-3.5-turbo for categories).
+# If receipt scanning is enabled, choose a vision-capable model (e.g. llava, gpt-4-turbo).
+# OPENAI_MODEL=llava

--- a/README.md
+++ b/README.md
@@ -124,6 +124,39 @@ NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT=true
 OPENAI_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
+### Custom OpenAI-compatible endpoint (BYO endpoint)
+
+Both AI features (receipt scanning and category extraction) support any OpenAI-compatible API endpoint. This lets you use providers like **Ollama**, **LM Studio**, or **OpenRouter** instead of the official OpenAI API.
+
+Two optional environment variables control this:
+
+| Variable          | Description                            | Default when omitted                                                          |
+| ----------------- | -------------------------------------- | ----------------------------------------------------------------------------- |
+| `OPENAI_BASE_URL` | Base URL of your OpenAI-compatible API | Requests go to the official OpenAI API (`https://api.openai.com/v1`)          |
+| `OPENAI_MODEL`    | Model identifier for chat completions  | Receipt scanning uses `gpt-4-turbo`; category extraction uses `gpt-3.5-turbo` |
+
+Example configuration using Ollama as the provider:
+
+```.env
+# AI feature flags (enable one or both)
+NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT=true
+NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT=true
+
+# Point to your local Ollama instance
+OPENAI_BASE_URL=http://localhost:11434/v1
+OPENAI_MODEL=llava
+
+# Required even for keyless providers — use a dummy value
+OPENAI_API_KEY=ollama
+```
+
+> **Important notes:**
+>
+> - `OPENAI_API_KEY` must still be set when AI features are enabled, even with providers that don't require a real key (Ollama, LM Studio). Use a dummy value like `ollama` or `not-needed`.
+> - `OPENAI_MODEL` applies to **both** receipt scanning and category extraction. Receipt scanning requires a **vision-capable model** since it processes images. If you have receipt scanning enabled, choose a multimodal model (e.g. `llava`, `gpt-4-turbo`).
+> - When `OPENAI_BASE_URL` is omitted, requests go to the official OpenAI API as before.
+> - When `OPENAI_MODEL` is omitted, each feature uses its own built-in default (`gpt-4-turbo` for receipts, `gpt-3.5-turbo` for categories).
+
 ## License
 
 MIT, see [LICENSE](./LICENSE).

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
@@ -1,24 +1,15 @@
 'use server'
+import { getAIClient, getAIModel } from '@/lib/ai-client'
 import { getCategories } from '@/lib/api'
-import { env } from '@/lib/env'
 import { formatCategoryForAIPrompt } from '@/lib/utils'
-import OpenAI from 'openai'
 import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/index.mjs'
-
-// Only initialize OpenAI if API key is available
-const getOpenAI = () => {
-  if (!env.OPENAI_API_KEY) {
-    throw new Error('OpenAI API key is not configured')
-  }
-  return new OpenAI({ apiKey: env.OPENAI_API_KEY })
-}
 
 export async function extractExpenseInformationFromImage(imageUrl: string) {
   'use server'
   const categories = await getCategories()
 
   const body: ChatCompletionCreateParamsNonStreaming = {
-    model: 'gpt-4-turbo',
+    model: getAIModel('receiptExtract'),
     messages: [
       {
         role: 'user',
@@ -43,7 +34,7 @@ export async function extractExpenseInformationFromImage(imageUrl: string) {
       },
     ],
   }
-  const openai = getOpenAI()
+  const openai = getAIClient()
   const completion = await openai.chat.completions.create(body)
 
   const [amountString, categoryId, date, title] = completion.choices

--- a/src/components/expense-form-actions.tsx
+++ b/src/components/expense-form-actions.tsx
@@ -1,16 +1,9 @@
 'use server'
+import { getAIClient, getAIModel } from '@/lib/ai-client'
 import { getCategories } from '@/lib/api'
 import { env } from '@/lib/env'
 import { formatCategoryForAIPrompt } from '@/lib/utils'
-import OpenAI from 'openai'
 import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/index.mjs'
-
-const getOpenAI = () => {
-  if (!env.OPENAI_API_KEY) {
-    throw new Error('OpenAI API key is not configured')
-  }
-  return new OpenAI({ apiKey: env.OPENAI_API_KEY })
-}
 
 /** Limit of characters to be evaluated. May help avoiding abuse when using AI. */
 const limit = 40 // ~10 tokens
@@ -28,7 +21,7 @@ export async function extractCategoryFromTitle(description: string) {
   const categories = await getCategories()
 
   const body: ChatCompletionCreateParamsNonStreaming = {
-    model: 'gpt-3.5-turbo',
+    model: getAIModel('categoryExtract'),
     temperature: 0.1, // try to be highly deterministic so that each distinct title may lead to the same category every time
     max_tokens: 1, // category ids are unlikely to go beyond ~4 digits so limit possible abuse
     messages: [
@@ -52,7 +45,7 @@ export async function extractCategoryFromTitle(description: string) {
     ],
   }
   try {
-    const completion = await getOpenAI().chat.completions.create(body)
+    const completion = await getAIClient().chat.completions.create(body)
     const messageContent = completion.choices.at(0)?.message.content
     // ensure the returned id actually exists
     const category = categories.find((category) => {

--- a/src/lib/ai-client.test.ts
+++ b/src/lib/ai-client.test.ts
@@ -1,0 +1,80 @@
+const mockOpenAIConstructor = jest.fn()
+
+jest.mock('openai', () => {
+  return {
+    __esModule: true,
+    default: class MockOpenAI {
+      constructor(opts: Record<string, unknown>) {
+        mockOpenAIConstructor(opts)
+      }
+    },
+  }
+})
+
+let mockEnv: Record<string, string | undefined> = {}
+
+jest.mock('@/lib/env', () => ({
+  get env() {
+    return mockEnv
+  },
+}))
+
+describe('ai-client', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockOpenAIConstructor.mockClear()
+    mockEnv = {}
+  })
+
+  describe('getAIModel', () => {
+    it("returns 'gpt-4-turbo' for receiptExtract when OPENAI_MODEL is unset", () => {
+      mockEnv = { OPENAI_API_KEY: 'test-key' }
+      const { getAIModel } = require('@/lib/ai-client')
+      expect(getAIModel('receiptExtract')).toBe('gpt-4-turbo')
+    })
+
+    it("returns 'gpt-3.5-turbo' for categoryExtract when OPENAI_MODEL is unset", () => {
+      mockEnv = { OPENAI_API_KEY: 'test-key' }
+      const { getAIModel } = require('@/lib/ai-client')
+      expect(getAIModel('categoryExtract')).toBe('gpt-3.5-turbo')
+    })
+
+    it('returns the configured OPENAI_MODEL value when set', () => {
+      mockEnv = { OPENAI_API_KEY: 'test-key', OPENAI_MODEL: 'llava' }
+      const { getAIModel } = require('@/lib/ai-client')
+      expect(getAIModel('receiptExtract')).toBe('llava')
+    })
+  })
+
+  describe('getAIClient', () => {
+    it('throws when OPENAI_API_KEY is not set', () => {
+      mockEnv = {}
+      const { getAIClient } = require('@/lib/ai-client')
+      expect(() => getAIClient()).toThrow(
+        'OpenAI API key is not configured. Set OPENAI_API_KEY to use AI features.',
+      )
+    })
+
+    it('calls OpenAI constructor without baseURL when OPENAI_BASE_URL is unset', () => {
+      mockEnv = { OPENAI_API_KEY: 'test-key' }
+      const { getAIClient } = require('@/lib/ai-client')
+      getAIClient()
+      expect(mockOpenAIConstructor).toHaveBeenCalledWith({
+        apiKey: 'test-key',
+      })
+    })
+
+    it('calls OpenAI constructor with baseURL when OPENAI_BASE_URL is set', () => {
+      mockEnv = {
+        OPENAI_API_KEY: 'test-key',
+        OPENAI_BASE_URL: 'http://localhost:11434/v1',
+      }
+      const { getAIClient } = require('@/lib/ai-client')
+      getAIClient()
+      expect(mockOpenAIConstructor).toHaveBeenCalledWith({
+        apiKey: 'test-key',
+        baseURL: 'http://localhost:11434/v1',
+      })
+    })
+  })
+})

--- a/src/lib/ai-client.ts
+++ b/src/lib/ai-client.ts
@@ -1,0 +1,41 @@
+import { env } from '@/lib/env'
+import OpenAI from 'openai'
+
+/** Default models per feature when OPENAI_MODEL is not set */
+export const AI_DEFAULT_MODELS = {
+  receiptExtract: 'gpt-4-turbo',
+  categoryExtract: 'gpt-3.5-turbo',
+} as const
+
+export type AIFeature = keyof typeof AI_DEFAULT_MODELS
+
+let _client: OpenAI | null = null
+
+/**
+ * Returns the shared OpenAI SDK instance configured from environment variables.
+ * Throws if OPENAI_API_KEY is not set.
+ */
+export function getAIClient(): OpenAI {
+  if (!env.OPENAI_API_KEY) {
+    throw new Error(
+      'OpenAI API key is not configured. Set OPENAI_API_KEY to use AI features.',
+    )
+  }
+
+  if (!_client) {
+    _client = new OpenAI({
+      apiKey: env.OPENAI_API_KEY,
+      ...(env.OPENAI_BASE_URL ? { baseURL: env.OPENAI_BASE_URL } : {}),
+    })
+  }
+
+  return _client
+}
+
+/**
+ * Returns the model identifier for a given AI feature.
+ * Uses OPENAI_MODEL env var when set, otherwise falls back to the feature-specific default.
+ */
+export function getAIModel(feature: AIFeature): string {
+  return env.OPENAI_MODEL ?? AI_DEFAULT_MODELS[feature]
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -32,6 +32,22 @@ const envSchema = z
       z.boolean().default(false),
     ),
     OPENAI_API_KEY: z.string().optional(),
+    OPENAI_BASE_URL: z.preprocess(
+      (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
+      z
+        .string()
+        .url()
+        .refine(
+          (url) => url.startsWith('http://') || url.startsWith('https://'),
+          { message: 'OPENAI_BASE_URL must use http or https scheme' },
+        )
+        .optional(),
+    ),
+    OPENAI_MODEL: z.preprocess((val) => {
+      if (typeof val !== 'string') return val
+      const trimmed = val.trim()
+      return trimmed === '' ? undefined : trimmed
+    }, z.string().max(128, 'OPENAI_MODEL must be at most 128 characters').optional()),
     NEXT_PUBLIC_APP_VERSION: z.string().optional().default('dev'),
     NEXT_PUBLIC_VAPID_PUBLIC_KEY: z
       .string()


### PR DESCRIPTION
## Summary

Add two optional environment variables that allow self-hosters to route AI requests to any OpenAI-compatible endpoint and choose a model:

- `OPENAI_BASE_URL` — custom API endpoint (Ollama, LM Studio, OpenRouter, etc.)
- `OPENAI_MODEL` — override model for both receipt scanning and category extraction

## Changes

- **`src/lib/env.ts`** — Extend Zod schema with validated optional fields (empty string → undefined preprocessing, URL scheme validation)
- **`src/lib/ai-client.ts`** (new) — Shared singleton factory (`getAIClient`) + model helper (`getAIModel`) with per-feature defaults
- **`src/lib/ai-client.test.ts`** (new) — Unit tests covering model defaults, overrides, baseURL passthrough, and missing key error
- **`create-from-receipt-button-actions.ts`** — Migrated to shared AI client
- **`expense-form-actions.tsx`** — Migrated to shared AI client
- **`.env.example`** — Added commented-out BYO variables with safe defaults
- **`README.md`** — Documented BYO endpoint in Opt-in features section with Ollama example

## Behaviour

| Variable omitted | Behaviour |
|---|---|
| `OPENAI_BASE_URL` | Requests go to official OpenAI API |
| `OPENAI_MODEL` | Receipt scanning uses `gpt-4-turbo`, categories use `gpt-3.5-turbo` |

No database changes. Fully backward-compatible — existing deployments unaffected.

## Testing

- 441 tests pass (`pnpm test`)
- Zero type errors (`pnpm check-types`)
