### PR TITLE
feat: allow arithmetic expressions in expense amount fields

### DIFF
--- a/.kiro/FEATURE_BACKLOG.md
+++ b/.kiro/FEATURE_BACKLOG.md
@@ -28,7 +28,9 @@ invitations, expenses with 4 split modes + reimbursements + notes + S3 documents
 recurring expenses (materialized on-read in `src/lib/api.ts`), duplicate detection,
 friends & direct expenses, balances with debt simplification + settlements + payment
 requests, activity log, granular push notifications, categories + auto-assign, stats,
-Splitwise/Knots import, CSV/JSON export.
+Splitwise/Knots import, CSV/JSON export, BYO OpenAI-compatible endpoint
+(`OPENAI_BASE_URL` / `OPENAI_MODEL` via `src/lib/ai-client.ts`), arithmetic
+expressions in amount fields (`src/lib/math-expression.ts`).
 
 ## Inspiration source
 
@@ -39,45 +41,30 @@ feature notes the upstream issue for demand signal. Import the _ideas_, not the 
 
 ## Suggested order
 
-1. `byo-openai-endpoint`
-2. `expense-amount-math-expressions`
-3. `copy-expense`
-4. `server-authoritative-currency-conversion`
-5. `multi-payer-expenses`
-6. `itemized-expenses`
-7. `account-overview-homepage`
-8. `profile-avatars`
+1. `copy-expense`
+2. `server-authoritative-currency-conversion`
+3. `multi-payer-expenses`
+4. `itemized-expenses`
+5. `account-overview-homepage`
+6. `profile-avatars`
 
 ---
 
-## 1. `byo-openai-endpoint` — Bring-your-own OpenAI-compatible endpoint
+## Done
 
-- **Size:** Small. **Upstream:** spliit #309/#378/#379.
-- **Summary:** Make the AI client (receipt scan + category deduction) point at any
-  OpenAI-compatible endpoint (Ollama, LM Studio, OpenRouter) via config instead of
-  hardcoding OpenAI.
-- **Touch points:** `src/lib/env.ts` (add optional `OPENAI_BASE_URL`, `OPENAI_MODEL`),
-  the OpenAI client init (search for `new OpenAI(` / the lazy-init client), receipt/
-  category extraction call sites, `.env.example`, README "Opt-in features" section.
-- **Requirement seeds:**
-  - WHEN `OPENAI_BASE_URL` is set, THE AI client SHALL send requests to that base URL.
-  - WHEN `OPENAI_MODEL` is set, THE AI client SHALL use that model; otherwise a sane default.
-  - WHEN neither AI feature flag is enabled, THE system SHALL not require any AI env var (keep current behaviour).
+### `byo-openai-endpoint` — Bring-your-own OpenAI-compatible endpoint
 
-## 2. `expense-amount-math-expressions` — Math in the amount field
+Shipped. Spec: `.kiro/specs/byo-openai-endpoint/`. Self-hosters can set
+`OPENAI_BASE_URL` and `OPENAI_MODEL` to route receipt/category AI to any
+OpenAI-compatible provider (Ollama, LM Studio, OpenRouter).
 
-- **Size:** Small. **Upstream:** spliit #184.
-- **Summary:** Allow arithmetic in the amount input (e.g. `12+4.50`, `100/3`) that
-  evaluates to the final amount on blur/submit.
-- **Touch points:** amount input in `src/app/groups/[groupId]/expenses/expense-form.tsx`
-  (and `payment-form.tsx`), a new pure parser util in `src/lib/` (with property tests),
-  amount validation in `src/lib/schemas.ts`.
-- **Requirement seeds:**
-  - WHEN the user enters a valid arithmetic expression, THE amount field SHALL evaluate it to a currency value on blur.
-  - IF the expression is invalid, THEN THE field SHALL show a validation error and block submit.
-  - THE evaluator SHALL support `+ - * /`, parentheses, and locale decimal separators (`.` and `,`).
+### `expense-amount-math-expressions` — Math in the amount field
 
-## 3. `copy-expense` — Duplicate an existing expense
+Shipped. Spec: `.kiro/specs/expense-amount-math-expressions/`. Users can type
+arithmetic expressions (e.g. `12+4.50`, `100/3`, `(50+25)*2`) in the amount
+input; evaluated on blur/submit via a pure recursive-descent parser.
+
+## 1. `copy-expense` — Duplicate an existing expense
 
 - **Size:** Small. **Upstream:** spliit #527.
 - **Summary:** A "Copy" action on an expense pre-fills the create form with the same
@@ -89,7 +76,7 @@ feature notes the upstream issue for demand signal. Import the _ideas_, not the 
   - THE copied expense date SHALL default to today.
   - THE copy action SHALL create a new independent expense on save (no link to the original).
 
-## 4. `server-authoritative-currency-conversion` — Automatic FX rates
+## 2. `server-authoritative-currency-conversion` — Automatic FX rates
 
 - **Size:** Medium. **Upstream:** spliit #513/#425 and #514/#515.
 - **Summary:** When an expense currency differs from the group currency, fetch the
@@ -104,7 +91,7 @@ feature notes the upstream issue for demand signal. Import the _ideas_, not the 
   - THE stored `originalAmount` SHALL use the same integer-cents convention as `amount`.
   - IF the FX provider is unavailable, THEN THE system SHALL let the user enter a manual rate and SHALL not block saving.
 
-## 5. `multi-payer-expenses` — One expense paid by several members
+## 3. `multi-payer-expenses` — One expense paid by several members
 
 - **Size:** Large. **Upstream:** spliit #14 (top-demand).
 - **Summary:** Support an expense funded by multiple payers, each with an amount/share,
@@ -119,7 +106,7 @@ userId, amount|shares}`; migrate existing single-payer rows), balance math in
   - THE balance calculation SHALL credit each payer by their contributed amount.
   - WHEN migrating existing data, THE migration SHALL convert every current `paidById` into a single-payer row with the full amount (no balance change).
 
-## 6. `itemized-expenses` — Split by line items (with tax & tip)
+## 4. `itemized-expenses` — Split by line items (with tax & tip)
 
 - **Size:** Large. **Upstream:** spliit #395.
 - **Summary:** Optionally break an expense into line items, assign each item to
@@ -133,7 +120,7 @@ userId, amount|shares}`; migrate existing single-payer rows), balance math in
   - THE system SHALL distribute tax and tip proportionally to each participant's item subtotal.
   - THE sum of per-person shares SHALL exactly equal the expense total (no lost cents).
 
-## 7. `account-overview-homepage` — Cross-group balance roll-up
+## 5. `account-overview-homepage` — Cross-group balance roll-up
 
 - **Size:** Medium. **Upstream:** spliit #509.
 - **Summary:** A logged-in landing page summarising the user's net position across all
@@ -146,7 +133,7 @@ userId, amount|shares}`; migrate existing single-payer rows), balance math in
   - THE overview SHALL list top balances with links to each group/friend.
   - THE aggregation SHALL run server-side via a single tRPC procedure.
 
-## 8. `profile-avatars` — Account profile photos
+## 6. `profile-avatars` — Account profile photos
 
 - **Size:** Medium.
 - **Summary:** Let users upload an avatar shown across account, group member lists, and

--- a/.kiro/specs/byo-openai-endpoint/.config.kiro
+++ b/.kiro/specs/byo-openai-endpoint/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "c77c9b53-fb1c-4f0c-8685-2b25e9676884", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/byo-openai-endpoint/design.md
+++ b/.kiro/specs/byo-openai-endpoint/design.md
@@ -1,0 +1,247 @@
+# Design Document: BYO OpenAI Endpoint
+
+## Overview
+
+This feature introduces two optional environment variables — `OPENAI_BASE_URL` and `OPENAI_MODEL` — that allow self-hosters to route AI requests (receipt scanning, category auto-assignment) to any OpenAI-compatible endpoint (Ollama, LM Studio, OpenRouter, etc.) and choose a specific model.
+
+The implementation consolidates the currently duplicated OpenAI client initialization (found in both `create-from-receipt-button-actions.ts` and `expense-form-actions.tsx`) into a single shared module. This shared module reads the new environment variables and passes them to the OpenAI SDK constructor. Each extractor then delegates model selection to a helper that reads `OPENAI_MODEL` with a per-feature default fallback.
+
+**Key design decisions:**
+
+- The new variables are entirely optional — no change in behavior for existing deployments.
+- Empty strings for `OPENAI_BASE_URL` and `OPENAI_MODEL` are preprocessed to `undefined` (treated as absent), avoiding spurious validation errors from Docker/compose environments that set vars to empty.
+- `OPENAI_BASE_URL` uses Zod `.url()` validation with an additional http/https scheme check to catch misconfigurations at startup (only applied to non-empty values after preprocessing).
+- `OPENAI_MODEL` applies globally to both extractors when set; each extractor retains its own default when unset (receipt: `gpt-4-turbo`, category: `gpt-3.5-turbo`). Documentation warns that receipt scanning requires a vision-capable model.
+- The shared AI client is a lazily-initialized singleton to avoid creating connections before they're needed.
+- `OPENAI_API_KEY` remains required when AI flags are on, even with providers that don't need a real key — a dummy value (e.g. `ollama`) may be used.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[src/lib/env.ts] -->|validates| B[OPENAI_API_KEY]
+    A -->|validates| C[OPENAI_BASE_URL]
+    A -->|validates| D[OPENAI_MODEL]
+
+    E[src/lib/ai-client.ts] -->|reads env| A
+    E -->|constructs| F[OpenAI SDK Instance]
+
+    G[create-from-receipt-button-actions.ts] -->|imports getAIClient, getAIModel| E
+    H[expense-form-actions.tsx] -->|imports getAIClient, getAIModel| E
+
+    G -->|chat.completions.create| F
+    H -->|chat.completions.create| F
+```
+
+The architecture is intentionally minimal: a single new module (`src/lib/ai-client.ts`) acts as the centralized factory. Both existing server action files replace their local `getOpenAI()` helpers with imports from this module.
+
+## Components and Interfaces
+
+### New File: `src/lib/ai-client.ts`
+
+```typescript
+import { env } from '@/lib/env'
+import OpenAI from 'openai'
+
+/** Default models per feature when OPENAI_MODEL is not set */
+export const AI_DEFAULT_MODELS = {
+  receiptExtract: 'gpt-4-turbo',
+  categoryExtract: 'gpt-3.5-turbo',
+} as const
+
+type AIFeature = keyof typeof AI_DEFAULT_MODELS
+
+let _client: OpenAI | null = null
+
+/**
+ * Returns the shared OpenAI SDK instance configured from environment variables.
+ * Throws if OPENAI_API_KEY is not set.
+ */
+export function getAIClient(): OpenAI {
+  if (!env.OPENAI_API_KEY) {
+    throw new Error(
+      'OpenAI API key is not configured. Set OPENAI_API_KEY to use AI features.',
+    )
+  }
+
+  if (!_client) {
+    _client = new OpenAI({
+      apiKey: env.OPENAI_API_KEY,
+      ...(env.OPENAI_BASE_URL ? { baseURL: env.OPENAI_BASE_URL } : {}),
+    })
+  }
+
+  return _client
+}
+
+/**
+ * Returns the model identifier for a given AI feature.
+ * Uses OPENAI_MODEL env var when set, otherwise falls back to the feature-specific default.
+ */
+export function getAIModel(feature: AIFeature): string {
+  return env.OPENAI_MODEL ?? AI_DEFAULT_MODELS[feature]
+}
+```
+
+### Modified File: `src/lib/env.ts`
+
+Add two new fields to the schema object. Both use a `preprocess` step to convert empty strings to `undefined`, so Docker/compose environments that set variables to `""` don't trigger validation errors:
+
+```typescript
+// New fields in the .object({...}) definition:
+OPENAI_BASE_URL: z.preprocess(
+  (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
+  z
+    .string()
+    .url()
+    .refine(
+      (url) => url.startsWith('http://') || url.startsWith('https://'),
+      { message: 'OPENAI_BASE_URL must use http or https scheme' },
+    )
+    .optional(),
+),
+OPENAI_MODEL: z.preprocess(
+  (val) => {
+    if (typeof val !== 'string') return val
+    const trimmed = val.trim()
+    return trimmed === '' ? undefined : trimmed
+  },
+  z
+    .string()
+    .max(128, 'OPENAI_MODEL must be at most 128 characters')
+    .optional(),
+),
+```
+
+The existing `OPENAI_API_KEY: z.string().optional()` and the `superRefine` block that enforces the API key when AI feature flags are enabled remain unchanged. `OPENAI_BASE_URL` and `OPENAI_MODEL` remain optional regardless of feature flags.
+
+### Modified File: `src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts`
+
+Remove the local `getOpenAI()` function and `OpenAI` import. Replace with:
+
+```typescript
+import { getAIClient, getAIModel } from '@/lib/ai-client'
+
+// In extractExpenseInformationFromImage:
+const body: ChatCompletionCreateParamsNonStreaming = {
+  model: getAIModel('receiptExtract'),
+  messages: [
+    /* unchanged */
+  ],
+}
+const openai = getAIClient()
+const completion = await openai.chat.completions.create(body)
+```
+
+### Modified File: `src/components/expense-form-actions.tsx`
+
+Remove the local `getOpenAI()` function and `OpenAI` import. Replace with:
+
+```typescript
+import { getAIClient, getAIModel } from '@/lib/ai-client'
+
+// In extractCategoryFromTitle:
+const body: ChatCompletionCreateParamsNonStreaming = {
+  model: getAIModel('categoryExtract'),
+  temperature: 0.1,
+  max_tokens: 1,
+  messages: [
+    /* unchanged */
+  ],
+}
+const completion = await getAIClient().chat.completions.create(body)
+```
+
+The early-return guard `if (!env.OPENAI_API_KEY) return { categoryId: 0 }` is retained as a fast-path; `getAIClient()` also throws if the key is missing, so this provides a graceful fallback for the category extractor.
+
+## Data Models
+
+No database schema changes. The feature is purely configuration-driven via environment variables.
+
+**Environment variable additions:**
+
+| Variable          | Type                    | Required | Default                                       | Description                            |
+| ----------------- | ----------------------- | -------- | --------------------------------------------- | -------------------------------------- |
+| `OPENAI_BASE_URL` | URL string (http/https) | No       | SDK default (`https://api.openai.com/v1`)     | Base URL for the OpenAI-compatible API |
+| `OPENAI_MODEL`    | String (1–128 chars)    | No       | Per-feature (`gpt-4-turbo` / `gpt-3.5-turbo`) | Model identifier for chat completions  |
+
+## Correctness Properties
+
+_A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: AI client factory configuration passthrough
+
+_For any_ valid environment configuration containing a non-empty `OPENAI_API_KEY` and a valid `OPENAI_BASE_URL`, the AI client factory SHALL construct the OpenAI SDK instance with that exact `apiKey` and `baseURL`, so that all downstream completion calls target the configured endpoint.
+
+**Validates: Requirements 1.1, 4.2**
+
+### Property 2: Env schema URL validation
+
+_For any_ string value assigned to `OPENAI_BASE_URL`, the env schema SHALL preprocess empty strings to `undefined` (accepted as absent), and for non-empty strings accept if and only if the value is a syntactically valid URL with an `http` or `https` scheme; all other non-empty strings (`ftp://` URLs, malformed input) SHALL be rejected with a validation error.
+
+**Validates: Requirements 1.3, 1.4, 6.1, 6.2, 6.3**
+
+### Property 3: Env schema model string validation
+
+_For any_ string value assigned to `OPENAI_MODEL`, the env schema SHALL preprocess by trimming whitespace and converting to `undefined` if the result is empty (accepted as absent); for non-empty trimmed results it SHALL accept if and only if the trimmed length does not exceed 128 characters.
+
+**Validates: Requirements 2.5**
+
+### Property 4: Model override flows to completion calls
+
+_For any_ non-empty `OPENAI_MODEL` value in the environment, both the receipt extractor and category extractor SHALL use that exact model identifier in their `chat.completions.create` call, overriding the built-in defaults.
+
+**Validates: Requirements 2.1, 2.2**
+
+## Error Handling
+
+| Scenario                                         | Behavior                                                                                                                                                                  |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OPENAI_BASE_URL` set to invalid non-empty URL   | Zod validation fails at startup; app does not start. Error message identifies `OPENAI_BASE_URL`.                                                                          |
+| `OPENAI_BASE_URL` set to empty string            | Preprocessed to `undefined`; treated as absent. App starts normally using SDK default.                                                                                    |
+| `OPENAI_MODEL` set to empty or whitespace-only   | Preprocessed (trim → empty → `undefined`); treated as absent. Per-feature defaults apply.                                                                                 |
+| `OPENAI_MODEL` > 128 characters                  | Zod `.max(128)` rejects; startup failure.                                                                                                                                 |
+| AI feature flag enabled without `OPENAI_API_KEY` | Existing `superRefine` rejects; startup failure (unchanged behavior).                                                                                                     |
+| `getAIClient()` called without `OPENAI_API_KEY`  | Throws `Error('OpenAI API key is not configured...')`. Category extractor catches this and returns `{ categoryId: 0 }`. Receipt extractor propagates the error to the UI. |
+| Custom endpoint unreachable at runtime           | OpenAI SDK throws a network error. Existing try/catch in category extractor returns fallback. Receipt extractor propagates to caller (existing behavior).                 |
+
+## Testing Strategy
+
+### Unit Tests (MVP — mandatory)
+
+All unit tests live in `src/lib/ai-client.test.ts`:
+
+- **Default model values:** Verify `getAIModel('receiptExtract')` returns `'gpt-4-turbo'` and `getAIModel('categoryExtract')` returns `'gpt-3.5-turbo'` when `OPENAI_MODEL` is unset (Req 2.3, 2.4).
+- **Factory throws without API key:** Verify `getAIClient()` throws when the key is absent (Req 4.4).
+- **No baseURL when not set:** Verify the OpenAI constructor is called without `baseURL` option when `OPENAI_BASE_URL` is unset (Req 1.2).
+- **baseURL passthrough:** Verify the OpenAI constructor receives `baseURL` when `OPENAI_BASE_URL` is set (Req 1.1).
+- **Model override:** Verify `getAIModel('receiptExtract')` returns the configured value when `OPENAI_MODEL` is set (Req 2.1, 2.2).
+
+### Property-Based Tests (post-MVP — optional)
+
+If added later, they live in `src/lib/ai-client.property.test.ts`. Using `fast-check` + Jest:
+
+- **Property 1** — AI client factory configuration passthrough (Req 1.1, 4.2)
+- **Property 2** — Env schema URL validation with empty-string preprocessing (Req 1.3, 6.1–6.3)
+- **Property 3** — Env schema model string validation with trim preprocessing (Req 2.5)
+- **Property 4** — Model override flows to completion calls (Req 2.1, 2.2)
+
+These are deferred from the MVP due to low ROI (validating Zod primitives and mocking extractors end-to-end). They can be added when the feature matures.
+
+### Documentation Updates (Manual Verification)
+
+- `.env.example` contains `OPENAI_BASE_URL` and `OPENAI_MODEL` with comments, plus a note about dummy `OPENAI_API_KEY` for keyless providers (Req 5.1, 5.4).
+- README "Opt-in features" section documents both variables with examples, model tradeoff warning, and dummy key guidance (Req 5.2, 5.3, 5.4, 5.5).
+
+## File Change Summary
+
+| File                                                                      | Action                | Description                                                                              |
+| ------------------------------------------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
+| `src/lib/ai-client.ts`                                                    | **Create**            | Shared AI client factory + model helper                                                  |
+| `src/lib/env.ts`                                                          | Modify                | Add `OPENAI_BASE_URL` and `OPENAI_MODEL` to Zod schema (with empty→undefined preprocess) |
+| `src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts` | Modify                | Replace local `getOpenAI()` with shared `getAIClient()` + `getAIModel()`                 |
+| `src/components/expense-form-actions.tsx`                                 | Modify                | Replace local `getOpenAI()` with shared `getAIClient()` + `getAIModel()`                 |
+| `.env.example`                                                            | Modify                | Add documented entries for new variables (incl. dummy API key note)                      |
+| `README.md`                                                               | Modify                | Update "Opt-in features" section with BYO endpoint docs, model tradeoff, dummy key       |
+| `src/lib/ai-client.test.ts`                                               | **Create**            | Unit tests for the shared module (MVP)                                                   |
+| `src/lib/ai-client.property.test.ts`                                      | **Create** (post-MVP) | Property-based tests (deferred)                                                          |

--- a/.kiro/specs/byo-openai-endpoint/requirements.md
+++ b/.kiro/specs/byo-openai-endpoint/requirements.md
@@ -1,0 +1,86 @@
+# Requirements Document
+
+## Introduction
+
+Allow self-hosters and developers to point the existing AI features (receipt scanning and category auto-assignment) at any OpenAI-compatible endpoint — such as Ollama, LM Studio, or OpenRouter — instead of requiring the official OpenAI API. This is achieved via two new optional environment variables (`OPENAI_BASE_URL` and `OPENAI_MODEL`) that configure the shared OpenAI client. When neither AI feature flag is enabled, no AI-related environment variable is required (preserving backward-compatible behaviour).
+
+## Glossary
+
+- **AI_Client**: The shared OpenAI SDK instance (`openai` npm package) used by receipt extraction and category extraction server actions.
+- **AI_Feature_Flag**: Either of the two boolean environment variables that gate AI functionality: `NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT` and `NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT`.
+- **Base_URL**: The root URL of an OpenAI-compatible HTTP API (e.g., `http://localhost:11434/v1` for Ollama, `https://openrouter.ai/api/v1` for OpenRouter).
+- **Model_Identifier**: A string identifying the model to use for chat completions (e.g., `gpt-4-turbo`, `llama3`, `mistral`).
+- **Env_Schema**: The Zod-based environment validation schema defined in `src/lib/env.ts`.
+- **Receipt_Extractor**: The server action that sends a receipt image to the AI and parses amount, category, date, and title from the response.
+- **Category_Extractor**: The server action that sends an expense title to the AI and returns a category ID.
+
+## Requirements
+
+### Requirement 1: Custom Base URL Configuration
+
+**User Story:** As a self-hoster, I want to configure a custom OpenAI-compatible base URL, so that AI requests are routed to my preferred provider or local model server.
+
+#### Acceptance Criteria
+
+1. WHEN `OPENAI_BASE_URL` is set in the environment to a non-empty value, THE AI_Client SHALL pass that value as the `baseURL` option to the OpenAI SDK constructor so that all chat completion requests are routed to the specified endpoint.
+2. WHEN `OPENAI_BASE_URL` is not set in the environment or is set to an empty string, THE AI_Client SHALL send requests to the default OpenAI API endpoint (`https://api.openai.com/v1`). An empty string SHALL be preprocessed to `undefined` (treated as absent), not rejected as a validation error.
+3. THE Env_Schema SHALL preprocess `OPENAI_BASE_URL` by converting empty strings to `undefined`, then accept the result as an optional string that, when defined, must pass Zod `.url()` validation (RFC-compliant URL with `http` or `https` scheme).
+4. IF `OPENAI_BASE_URL` is set to a non-empty value that fails URL validation (malformed URL or non-http/https scheme), THEN THE Env_Schema SHALL reject the configuration at application startup and report a validation error indicating the provided base URL is not a valid URL.
+
+### Requirement 2: Custom Model Configuration
+
+**User Story:** As a self-hoster, I want to specify which model to use for AI features, so that I can choose a model available on my endpoint that balances cost and quality.
+
+#### Acceptance Criteria
+
+1. WHEN `OPENAI_MODEL` is set to a non-empty value in the environment, THE Category_Extractor SHALL use that Model_Identifier for chat completions instead of the hardcoded default.
+2. WHEN `OPENAI_MODEL` is set to a non-empty value in the environment, THE Receipt_Extractor SHALL use that Model_Identifier for chat completions instead of the hardcoded default.
+3. WHEN `OPENAI_MODEL` is not set in the environment, THE Category_Extractor SHALL default to `gpt-3.5-turbo`.
+4. WHEN `OPENAI_MODEL` is not set in the environment, THE Receipt_Extractor SHALL default to `gpt-4-turbo`.
+5. THE Env_Schema SHALL preprocess `OPENAI_MODEL` by trimming whitespace and converting the result to `undefined` if empty, then accept it as an optional string with a maximum length of 128 characters. Whitespace-only values (after trim → empty) are treated as absent, not as validation errors.
+6. WHEN `OPENAI_MODEL` is set, THE system SHALL apply the same model to both Receipt_Extractor and Category_Extractor. The documentation SHALL note that receipt scanning requires a vision-capable model, so self-hosters using local providers (Ollama, LM Studio) SHOULD choose a multimodal model if receipt scanning is enabled.
+
+### Requirement 3: Backward-Compatible Feature Gating
+
+**User Story:** As an operator who does not use AI features, I want the system to continue working without any AI environment variables, so that nothing breaks for deployments that do not opt in.
+
+#### Acceptance Criteria
+
+1. WHEN neither AI_Feature_Flag is enabled, THE Env_Schema SHALL accept the configuration as valid when `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and `OPENAI_MODEL` are all absent from the environment.
+2. WHEN at least one AI_Feature_Flag is enabled and `OPENAI_API_KEY` is set to a non-empty string, THE Env_Schema SHALL accept the configuration as valid.
+3. IF at least one AI_Feature_Flag is enabled and `OPENAI_API_KEY` is absent or empty, THEN THE Env_Schema SHALL reject the configuration with a validation error indicating that `OPENAI_API_KEY` is required when AI features are enabled.
+4. WHEN at least one AI_Feature_Flag is enabled and `OPENAI_BASE_URL` is not set, THE Env_Schema SHALL accept the configuration as valid (Base_URL remains optional regardless of feature flags).
+5. WHEN at least one AI_Feature_Flag is enabled and `OPENAI_MODEL` is not set, THE Env_Schema SHALL accept the configuration as valid (Model_Identifier remains optional regardless of feature flags).
+
+### Requirement 4: Centralized AI Client Initialization
+
+**User Story:** As a developer, I want a single shared AI client factory so that configuration changes apply uniformly to all AI call sites.
+
+#### Acceptance Criteria
+
+1. THE AI_Client initialization logic SHALL exist in a single shared module rather than being duplicated across call sites.
+2. WHEN the AI_Client is instantiated, THE shared module SHALL pass `apiKey` and, if configured, `baseURL` from the environment to the OpenAI SDK constructor.
+3. WHEN any server action invokes the AI_Client, THE server action SHALL import and call the shared module's factory function instead of directly instantiating the OpenAI SDK.
+4. IF `OPENAI_API_KEY` is not set when the shared module's factory function is called, THEN THE shared module SHALL throw an error indicating that the API key is not configured.
+
+### Requirement 5: Environment Example and Documentation
+
+**User Story:** As a developer setting up the project, I want clear documentation of the new environment variables, so that I can configure an alternative AI endpoint without reading source code.
+
+#### Acceptance Criteria
+
+1. THE `.env.example` file SHALL list `OPENAI_BASE_URL` and `OPENAI_MODEL` grouped with the existing OpenAI-related variables, each accompanied by a comment stating the variable's purpose and a syntactically valid example value.
+2. THE README "Opt-in features" section SHALL document `OPENAI_BASE_URL` and `OPENAI_MODEL`, stating that both are optional, listing compatible providers (Ollama, LM Studio, OpenRouter), and including at least one `.env` code block demonstrating both variables configured for a non-OpenAI provider.
+3. THE README "Opt-in features" section SHALL state the default behavior when `OPENAI_BASE_URL` is omitted (requests go to the official OpenAI API) and when `OPENAI_MODEL` is omitted (the system uses its built-in default model per feature).
+4. THE documentation (README and `.env.example`) SHALL note that `OPENAI_API_KEY` remains required when AI feature flags are enabled, even with providers that do not require a real key (e.g. Ollama, LM Studio). A dummy value such as `ollama` or `not-needed` may be used.
+5. THE documentation SHALL warn that `OPENAI_MODEL` applies to both receipt scanning and category extraction; receipt scanning requires a vision-capable model, so self-hosters SHOULD choose a multimodal model (e.g. `llava`, `gpt-4-turbo`) if receipt scanning is enabled.
+
+### Requirement 6: Validation of Custom Base URL Format
+
+**User Story:** As an operator, I want the system to reject malformed base URLs at startup, so that misconfiguration is caught early rather than causing runtime failures.
+
+#### Acceptance Criteria
+
+1. WHEN `OPENAI_BASE_URL` is set to a non-empty value that does not conform to URL syntax with an `http` or `https` scheme, THE Env_Schema SHALL reject the configuration and prevent the application from starting, reporting a validation error message that identifies `OPENAI_BASE_URL` as the invalid variable.
+2. WHEN `OPENAI_BASE_URL` is set to a valid URL with an `http` or `https` scheme (including URLs with a path component such as `/v1`), THE Env_Schema SHALL accept the configuration without error.
+3. WHEN `OPENAI_BASE_URL` is set to an empty string, THE Env_Schema SHALL preprocess it to `undefined` (treated as absent) and accept the configuration without error.

--- a/.kiro/specs/byo-openai-endpoint/tasks.md
+++ b/.kiro/specs/byo-openai-endpoint/tasks.md
@@ -1,0 +1,95 @@
+# Implementation Plan: BYO OpenAI Endpoint
+
+## Overview
+
+Introduce two optional environment variables (`OPENAI_BASE_URL` and `OPENAI_MODEL`) that allow self-hosters to route AI requests to any OpenAI-compatible endpoint and choose a model. Implementation consolidates duplicated OpenAI client initialization into a shared module, updates the env schema with validation (empty string = unset via preprocess), and migrates both existing server actions to use the shared client.
+
+## Tasks
+
+- [x] 1. Extend environment schema with new variables
+  - [x] 1.1 Add `OPENAI_BASE_URL` and `OPENAI_MODEL` to `src/lib/env.ts` Zod schema
+    - Add `OPENAI_BASE_URL` with `z.preprocess()` that converts empty string → `undefined`, then `.string().url()` + http/https scheme `.refine()` + `.optional()`
+    - Add `OPENAI_MODEL` with `z.preprocess()` that trims and converts empty → `undefined`, then `.string().max(128).optional()`
+    - Place both fields adjacent to the existing `OPENAI_API_KEY` field
+    - Existing `superRefine` block and `OPENAI_API_KEY` handling remain unchanged
+    - _Requirements: 1.3, 1.4, 2.5, 3.1, 3.4, 3.5, 6.1, 6.2, 6.3_
+
+- [x] 2. Create shared AI client module
+  - [x] 2.1 Create `src/lib/ai-client.ts` with `getAIClient()` and `getAIModel()` functions
+    - Export `AI_DEFAULT_MODELS` constant with `receiptExtract: 'gpt-4-turbo'` and `categoryExtract: 'gpt-3.5-turbo'`
+    - Export `AIFeature` type (`keyof typeof AI_DEFAULT_MODELS`)
+    - Implement `getAIClient()` as a lazy singleton that reads `env.OPENAI_API_KEY` and optionally `env.OPENAI_BASE_URL`
+    - Implement `getAIModel(feature)` returning `env.OPENAI_MODEL ?? AI_DEFAULT_MODELS[feature]`
+    - Throw descriptive error from `getAIClient()` if `OPENAI_API_KEY` is not set
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 1.1, 1.2, 2.1, 2.2, 2.3, 2.4_
+
+  - [x] 2.2 Write unit tests for AI client module
+    - Test `getAIModel('receiptExtract')` returns `'gpt-4-turbo'` when `OPENAI_MODEL` unset
+    - Test `getAIModel('categoryExtract')` returns `'gpt-3.5-turbo'` when `OPENAI_MODEL` unset
+    - Test `getAIModel('receiptExtract')` returns configured value when `OPENAI_MODEL` is set
+    - Test `getAIClient()` throws when `OPENAI_API_KEY` is not set
+    - Test OpenAI constructor is called without `baseURL` when `OPENAI_BASE_URL` is unset
+    - Test OpenAI constructor receives `baseURL` when `OPENAI_BASE_URL` is set
+    - Create test file: `src/lib/ai-client.test.ts`
+    - _Requirements: 2.3, 2.4, 4.4, 1.1, 1.2_
+
+- [x] 3. Migrate server actions to shared AI client
+  - [x] 3.1 Refactor `src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts`
+    - Remove local `getOpenAI()` function and direct `OpenAI` import
+    - Import `getAIClient` and `getAIModel` from `@/lib/ai-client`
+    - Replace hardcoded `model: 'gpt-4-turbo'` with `getAIModel('receiptExtract')`
+    - Replace `getOpenAI()` call with `getAIClient()`
+    - Remove unused `openai` package import if no longer needed directly
+    - _Requirements: 4.3, 2.2, 1.1_
+
+  - [x] 3.2 Refactor `src/components/expense-form-actions.tsx`
+    - Remove local `getOpenAI()` function and direct `OpenAI` import
+    - Import `getAIClient` and `getAIModel` from `@/lib/ai-client`
+    - Replace hardcoded `model: 'gpt-3.5-turbo'` with `getAIModel('categoryExtract')`
+    - Replace `getOpenAI()` call with `getAIClient()`
+    - Retain the early-return guard `if (!env.OPENAI_API_KEY) return { categoryId: 0 }`
+    - _Requirements: 4.3, 2.1, 1.1_
+
+- [x] 4. Checkpoint — Ensure all tests pass
+  - Run `pnpm test` and `pnpm check-types`; fix any regressions.
+
+- [x] 5. Update documentation and environment example
+  - [x] 5.1 Update `.env.example` with new variables
+    - Add `OPENAI_BASE_URL` and `OPENAI_MODEL` grouped with existing OpenAI-related variables
+    - Include comments explaining each variable's purpose
+    - Include syntactically valid example values (e.g., `http://localhost:11434/v1` for base URL, `llava` for model)
+    - Add a comment noting that `OPENAI_API_KEY` is still required even with keyless providers — use a dummy value (e.g. `ollama`)
+    - _Requirements: 5.1, 5.4_
+
+  - [x] 5.2 Update README "Opt-in features" section with BYO endpoint documentation
+    - Document `OPENAI_BASE_URL` and `OPENAI_MODEL` as optional variables
+    - List compatible providers (Ollama, LM Studio, OpenRouter)
+    - Include at least one `.env` code block demonstrating both variables configured for a non-OpenAI provider (with dummy API key)
+    - State default behavior when each variable is omitted
+    - Warn that `OPENAI_MODEL` applies to both features; receipt scanning needs a vision-capable model (recommend multimodal, e.g. `llava`, `gpt-4-turbo`)
+    - Note that `OPENAI_API_KEY` must be set to a dummy value for keyless providers
+    - _Requirements: 5.2, 5.3, 5.4, 5.5_
+
+- [x] 6. Final checkpoint — Ensure all tests pass
+  - Run `pnpm test` and `pnpm check-types`; fix any regressions.
+
+## Notes
+
+- Empty string values for `OPENAI_BASE_URL` and `OPENAI_MODEL` are preprocessed to `undefined` — this avoids Docker/compose environments triggering validation errors when vars are set but empty.
+- Unit tests live in `src/lib/ai-client.test.ts`. Property tests (if added later) go to `src/lib/ai-client.property.test.ts`.
+- Property tests (P1–P4 from design) are deferred from MVP due to low ROI for validating Zod primitives and mocking extractors end-to-end.
+- The singleton pattern in `ai-client.ts` requires resetting state between tests (use `jest.resetModules()`).
+- No database migrations needed — this feature is purely configuration-driven.
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["2.1"] },
+    { "id": 2, "tasks": ["2.2", "3.1", "3.2"] },
+    { "id": 3, "tasks": ["5.1", "5.2"] }
+  ]
+}
+```

--- a/.kiro/specs/expense-amount-math-expressions/.config.kiro
+++ b/.kiro/specs/expense-amount-math-expressions/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "a3f7e8d2-9b14-4c6a-b8e5-1d4f2a7c9e03", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/expense-amount-math-expressions/design.md
+++ b/.kiro/specs/expense-amount-math-expressions/design.md
@@ -1,0 +1,332 @@
+# Design Document: Expense Amount Math Expressions
+
+## Overview
+
+This feature adds arithmetic expression evaluation to the expense and payment amount fields, letting users type expressions like `12+4.50`, `100/3`, or `(50+25)*2` directly into the amount input. The expression is evaluated on blur (or at form submission time if still unevaluated) and the result replaces the raw text.
+
+The design introduces:
+
+1. A **pure expression evaluator module** (`src/lib/math-expression.ts`) implementing a recursive-descent parser and tree-walking evaluator.
+2. An **update to `CurrencyAmountInput`** to invoke the evaluator on blur and display the computed result.
+3. A **Zod schema transform** in `src/lib/schemas.ts` that evaluates any remaining expression string before numeric validation.
+
+The evaluator is intentionally pure (no DOM, no React, no I/O) to enable exhaustive property-based testing with `fast-check`.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph UI Layer
+        EF[ExpenseForm / PaymentForm]
+        CAI[CurrencyAmountInput]
+    end
+
+    subgraph Pure Logic
+        ME[math-expression.ts]
+        subgraph Evaluator
+            TOK[tokenize]
+            PARSE[parse → AST]
+            EVAL[evaluate AST → number]
+            PP[prettyPrint AST → string]
+        end
+    end
+
+    subgraph Validation
+        ZOD[schemas.ts – amount transform]
+    end
+
+    EF -->|field.value| CAI
+    CAI -->|onBlur| ME
+    ME --> TOK --> PARSE --> EVAL
+    PARSE --> PP
+    CAI -->|onValueChange(result)| EF
+    EF -->|submit| ZOD
+    ZOD -->|string input| ME
+    ZOD -->|numeric output| DB[(Persist)]
+```
+
+### Parsing Approach: Recursive Descent
+
+A hand-written recursive-descent parser is chosen over alternatives (regex, `eval`, or library-based) because:
+
+- **Security**: No use of `eval()` or `Function()` — the parser only recognizes arithmetic tokens.
+- **Simplicity**: The grammar is tiny (4 operators, parentheses, unary minus, decimal numbers). A recursive-descent parser is ~80 lines of TypeScript.
+- **Error reporting**: Hand-written parsers produce precise error positions, enabling future UX improvements (e.g., inline caret highlighting).
+- **No dependencies**: Keeps the bundle small; no runtime dependency added.
+- **Testability**: The AST is a plain data structure, enabling structural property-based tests.
+
+### Grammar (EBNF)
+
+```
+Expression  = Term (('+' | '-') Term)*
+Term        = Factor (('*' | '/') Factor)*
+Factor      = '-' Factor | Atom
+Atom        = '(' Expression ')' | Number
+Number      = Digit+ (DecimalSep Digit+)?
+DecimalSep  = '.' | ','
+Digit       = '0' | '1' | ... | '9'
+```
+
+This grammar naturally encodes standard operator precedence (multiplication/division bind tighter than addition/subtraction) and supports unary minus at the start or after `(`.
+
+## Components and Interfaces
+
+### 1. `src/lib/math-expression.ts` — Pure Evaluator Module
+
+```typescript
+// --- AST Types ---
+
+type NumberNode = { type: 'number'; value: number }
+type UnaryNode = { type: 'unary'; operator: '-'; operand: ExprNode }
+type BinaryNode = {
+  type: 'binary'
+  operator: '+' | '-' | '*' | '/'
+  left: ExprNode
+  right: ExprNode
+}
+type ExprNode = NumberNode | UnaryNode | BinaryNode
+
+// --- Result Types ---
+
+type EvalSuccess = { ok: true; value: number }
+type EvalError = { ok: false; error: string }
+type EvalResult = EvalSuccess | EvalError
+
+// --- Public API ---
+
+/** Evaluate an arithmetic expression string to a numeric result. */
+export function evaluate(input: string): EvalResult
+
+/**
+ * Parse an expression string into an AST.
+ * Returns the AST or an error.
+ */
+export function parse(
+  input: string,
+): { ok: true; ast: ExprNode } | { ok: false; error: string }
+
+/**
+ * Pretty-print an AST back into a canonical expression string.
+ * Uses minimal parentheses based on operator precedence.
+ */
+export function prettyPrint(node: ExprNode): string
+
+/**
+ * Check if a string contains any arithmetic operators,
+ * indicating it's an expression rather than a plain number.
+ */
+export function isExpression(input: string): boolean
+```
+
+**Design decisions:**
+
+- `evaluate` is the primary entry point for the UI and schema layers. It encapsulates tokenize → parse → eval.
+- `parse` and `prettyPrint` are exposed for round-trip property testing and potential future use (e.g., showing a preview of the parsed expression).
+- `isExpression` is a fast regex check (`/[+\-*/()]/` after stripping leading minus) used by the schema to decide whether to attempt evaluation or fall through to plain `Number()` parsing.
+- The result type uses a discriminated union (`ok: true/false`) rather than exceptions, making error handling explicit and composable.
+
+### 2. `src/components/currency-amount-input.tsx` — Updated Component
+
+Changes to the existing component:
+
+```typescript
+// New import
+import { evaluate, isExpression } from '@/lib/math-expression'
+
+// Updated onBlur handler (inside the component):
+onBlur={(event) => {
+  setIsFocused(false)
+
+  if (isExpression(draft)) {
+    const result = evaluate(draft)
+    if (result.ok) {
+      // Format the result for the currency and propagate
+      const formatted = String(result.value)
+      setDraft('')
+      onValueChange(formatted)
+    } else {
+      // Leave the draft as-is; validation will catch it
+      setDraft('')
+      onValueChange(draft) // propagate raw for schema validation
+    }
+  } else {
+    setDraft('')
+  }
+
+  onBlur?.(event)
+}}
+```
+
+Additional changes:
+
+- `inputMode` changes from `"decimal"` to `"text"` to allow operators on mobile keyboards.
+- `placeholder` updated to hint expression support (e.g., `"0.00 or 10+5"`).
+- The `enforceCurrencyPattern` call in `onChange` is conditionally bypassed when the input contains operator characters — instead, a lighter `enforceExpressionPattern` is used that allows `+`, `-`, `*`, `/`, `(`, `)`, digits, `.`, `,`, and whitespace.
+
+### 3. `src/lib/schemas.ts` — Amount Schema Transform
+
+The existing amount field schema uses a `z.string().transform()` that calls `Number(value)`. This is updated to first attempt expression evaluation:
+
+```typescript
+import { evaluate, isExpression } from '@/lib/math-expression'
+
+// Shared transform for amount fields
+function expressionToNumber(value: string, ctx: z.RefinementCtx): number {
+  // Fast path: plain number
+  if (!isExpression(value)) {
+    const num = Number(value)
+    if (Number.isNaN(num)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'invalidNumber' })
+      return 0
+    }
+    return num
+  }
+
+  // Expression path
+  const result = evaluate(value)
+  if (!result.ok) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'invalidExpression' })
+    return 0
+  }
+  return result.value
+}
+```
+
+This transform is used in both `expenseFormSchema.amount` and `paymentFormSchema.amount`.
+
+### 4. `src/lib/currency-input.ts` — New Helper
+
+A new exported function for expression-aware input filtering:
+
+```typescript
+/**
+ * Allow characters valid in arithmetic expressions:
+ * digits, decimal separators (. ,), operators (+ - * /), parentheses, whitespace.
+ */
+export const enforceExpressionPattern = (value: string): string =>
+  value.replace(/[^\d.,+\-*/() ]/g, '')
+```
+
+## Data Models
+
+No database schema changes are required. The expression is always evaluated to a plain number before persistence. The amount field in Prisma (`amount Int` stored as minor units) remains unchanged.
+
+**Data flow:**
+
+1. User types `"50+25"` → stored in form state as string `"50+25"`
+2. On blur → evaluated to `75` → `onValueChange("75")` → form state becomes `"75"`
+3. On submit → schema transform receives `"75"` (or raw expression if blur didn't fire) → evaluates to `75` → validated → converted to minor units (7500) → persisted
+
+## Correctness Properties
+
+_A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: Evaluator Arithmetic Correctness
+
+_For any_ valid arithmetic expression composed of numbers and the operators `+`, `-`, `*`, `/` with optional parentheses and unary minus, the `evaluate` function SHALL produce a result numerically equal to the same expression evaluated by JavaScript's native arithmetic (within floating-point tolerance).
+
+**Validates: Requirements 1.2, 3.1, 3.2, 3.3, 3.4**
+
+### Property 2: Parse/Print Round-Trip
+
+_For any_ valid arithmetic expression string, `parse(prettyPrint(parse(expr).ast)).ast` SHALL be structurally equivalent to `parse(expr).ast` — that is, parsing, pretty-printing, and re-parsing produces an equivalent expression tree.
+
+**Validates: Requirements 6.3, 6.4**
+
+### Property 3: Locale Decimal Equivalence
+
+_For any_ valid arithmetic expression containing `.` as a decimal separator, replacing each `.` with `,` (in numeric literal positions) SHALL produce an expression that evaluates to the same numeric result.
+
+**Validates: Requirements 4.1, 4.2**
+
+### Property 4: Invalid Input Rejection
+
+_For any_ string containing characters outside the allowed set (digits, `.`, `,`, `+`, `-`, `*`, `/`, `(`, `)`, whitespace), OR containing syntax errors (unbalanced parentheses, consecutive operators, trailing operators, empty parentheses, division by zero), the `evaluate` function SHALL return `{ ok: false }`.
+
+**Validates: Requirements 3.5, 5.1, 5.2, 5.3, 5.4**
+
+### Property 5: Schema Expression Evaluation Consistency
+
+_For any_ valid arithmetic expression string, passing it through the Zod amount schema transform SHALL produce a numeric value equal to `evaluate(expr).value`.
+
+**Validates: Requirements 2.1, 2.2**
+
+## Error Handling
+
+| Scenario                                        | Layer                                                                           | Behavior                                   |
+| ----------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------ |
+| Syntax error (e.g., `5++3`, `(5+)`, `()`)       | Evaluator → returns `{ ok: false, error: "..." }`                               | UI shows validation error via form message |
+| Invalid characters (e.g., `5+abc`)              | `enforceExpressionPattern` strips them on input; if bypassed, evaluator rejects | Schema rejects on submit                   |
+| Division by zero (e.g., `10/0`, `5/(3-3)`)      | Evaluator detects non-finite result → returns `{ ok: false }`                   | UI shows "invalid expression" error        |
+| Overflow / NaN                                  | Evaluator checks `Number.isFinite(result)` → returns `{ ok: false }`            | Schema rejects                             |
+| Unbalanced parentheses (e.g., `(5+3`, `5+3)`)   | Parser detects during recursive descent → returns error with position           | UI shows validation error                  |
+| Empty input                                     | `isExpression("")` returns `false` → falls through to existing behavior         | Existing "amount required" validation      |
+| Expression evaluates to zero                    | Evaluator succeeds with `0` → existing `amountNotZero` refinement rejects       | Existing error message shown               |
+| Expression evaluates to negative (payment form) | Evaluator succeeds → existing `amount > 0` refinement rejects                   | Existing error message shown               |
+
+### i18n Error Messages
+
+New message key added to `messages/*.json`:
+
+```json
+{
+  "ExpenseForm": {
+    "invalidExpression": "Invalid expression. Use numbers and +, -, *, / operators."
+  }
+}
+```
+
+## Testing Strategy
+
+### Property-Based Tests (`src/lib/math-expression.property.test.ts`)
+
+Using `fast-check` (already a devDependency), with 200 runs per property:
+
+| Property                  | Generator Strategy                                                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| 1: Arithmetic Correctness | Generate random ASTs (depth ≤ 4), pretty-print to string, evaluate, compare to reference JS computation on the AST                        |
+| 2: Round-Trip             | Generate random ASTs, prettyPrint → parse → compare AST equality                                                                          |
+| 3: Locale Equivalence     | Generate expressions with `.` decimals, create `,` variant, compare evaluate results                                                      |
+| 4: Invalid Rejection      | Generate strings with invalid chars (fc.string filtered), and structurally invalid expressions (unbalanced parens, consecutive operators) |
+| 5: Schema Consistency     | Generate valid expressions, run through Zod schema, compare to direct evaluate                                                            |
+
+**Configuration:**
+
+- Minimum 200 iterations per property (`numRuns: 200`)
+- Each test tagged with: `Feature: expense-amount-math-expressions, Property N: <title>`
+
+### Unit Tests (`src/lib/math-expression.test.ts`)
+
+Example-based tests for:
+
+- Specific expressions: `"12+4.50"` → `16.5`, `"100/3"` → `33.333...`, `"(50+25)*2"` → `150`
+- Edge cases: `"-5+3"` → `-2`, `"(-5+3)"` → `-2`, `"0.1+0.2"` → `0.3` (within tolerance)
+- Division by zero: `"10/0"` → error
+- Unbalanced parens: `"(5+3"` → error
+- Empty parentheses: `"()"` → error
+- Comma decimals: `"10,50+2,25"` → `12.75`
+- Whitespace: `" 5 + 3 "` → `8`
+- Large numbers: `"99999*99999"` → `9999800001`
+- Trailing operator: `"5+"` → error
+
+### Component Tests
+
+Example-based tests for `CurrencyAmountInput`:
+
+- Verify `inputMode="text"` attribute
+- Verify placeholder includes expression hint
+- Verify onBlur evaluates expression and calls onValueChange with result
+- Verify focused state shows raw draft text
+
+## File Change Summary
+
+| File                                       | Change                                                                                                                   |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `src/lib/math-expression.ts`               | **New** — Pure evaluator module (tokenize, parse, evaluate, prettyPrint, isExpression)                                   |
+| `src/lib/math-expression.test.ts`          | **New** — Unit tests for the evaluator                                                                                   |
+| `src/lib/math-expression.property.test.ts` | **New** — Property-based tests (5 properties, 200 runs each)                                                             |
+| `src/components/currency-amount-input.tsx` | **Modified** — Add expression evaluation on blur, change inputMode, update placeholder, conditional input filtering      |
+| `src/lib/currency-input.ts`                | **Modified** — Add `enforceExpressionPattern` helper                                                                     |
+| `src/lib/schemas.ts`                       | **Modified** — Update amount transforms to evaluate expressions before numeric coercion; add `expressionToNumber` helper |
+| `messages/en-US.json`                      | **Modified** — Add `invalidExpression` message key                                                                       |
+| `messages/de-DE.json` (and other locales)  | **Modified** — Add translated `invalidExpression` message                                                                |

--- a/.kiro/specs/expense-amount-math-expressions/requirements.md
+++ b/.kiro/specs/expense-amount-math-expressions/requirements.md
@@ -1,0 +1,101 @@
+# Requirements Document
+
+## Introduction
+
+Allow users to enter arithmetic expressions (e.g. `12+4.50`, `100/3`, `(50+25)*2`) in the expense and payment amount fields. The expression is evaluated to a final currency value on blur or form submission, replacing the raw text with the computed result. This removes the need for users to reach for a calculator when splitting bills or summing line items mentally.
+
+The feature introduces a pure expression evaluator utility in `src/lib/`, updates the `CurrencyAmountInput` component to accept and resolve expressions, and adjusts Zod validation in `src/lib/schemas.ts` to allow expression strings before coercion.
+
+## Glossary
+
+- **Expression_Evaluator**: A pure utility module (`src/lib/math-expression.ts`) responsible for parsing and evaluating arithmetic expression strings into numeric results.
+- **Amount_Input**: The `CurrencyAmountInput` component used in `ExpenseForm` and `PaymentForm` for entering monetary values.
+- **Arithmetic_Expression**: A string containing decimal numbers and the operators `+`, `-`, `*`, `/`, and parentheses `(` `)`, with locale-aware decimal separators (`.` or `,`).
+- **Evaluation**: The process of computing the numeric result of a valid Arithmetic_Expression.
+- **Locale_Decimal_Separator**: The character used as a decimal point in the user's locale (`.` in `en-US`, `,` in `de-DE`).
+- **Amount_Schema**: The Zod validation schema for the `amount` field in `expenseFormSchema` and `paymentFormSchema` in `src/lib/schemas.ts`.
+
+## Requirements
+
+### Requirement 1: Expression Evaluation on Blur
+
+**User Story:** As a user, I want to type arithmetic expressions into the amount field and have them evaluated automatically when I leave the field, so that I can quickly compute totals without using a separate calculator.
+
+#### Acceptance Criteria
+
+1. WHEN the user enters a valid Arithmetic_Expression into the Amount_Input and the field loses focus, THE Amount_Input SHALL evaluate the expression and replace the displayed text with the computed numeric result formatted according to the field's currency and locale.
+2. WHEN the user enters a plain numeric value (no operators) into the Amount_Input, THE Amount_Input SHALL continue to behave as it does today with no change in formatting or validation.
+3. WHEN the evaluated result contains more decimal places than the currency allows, THE Amount_Input SHALL round the result to the currency's `decimal_digits` using the locale-standard rounding provided by `Intl.NumberFormat`.
+
+### Requirement 2: Expression Evaluation on Submit
+
+**User Story:** As a user, I want the system to evaluate any unevaluated expression in the amount field when I submit the form, so that an expression left in the field does not block saving.
+
+#### Acceptance Criteria
+
+1. WHEN the user submits the expense or payment form and the amount field contains a valid Arithmetic_Expression that has not yet been evaluated, THE Amount_Schema SHALL evaluate the expression and use the resulting numeric value for validation and persistence.
+2. WHEN the evaluated numeric result passes all existing amount constraints (non-zero, within maximum), THE form SHALL proceed with saving using the evaluated value.
+
+### Requirement 3: Supported Operators and Syntax
+
+**User Story:** As a user, I want to use common arithmetic operators and parentheses in the amount field, so that I can express calculations naturally.
+
+#### Acceptance Criteria
+
+1. THE Expression_Evaluator SHALL support the binary operators addition (`+`), subtraction (`-`), multiplication (`*`), and division (`/`).
+2. THE Expression_Evaluator SHALL support parentheses `(` and `)` for explicit grouping of sub-expressions.
+3. THE Expression_Evaluator SHALL respect standard operator precedence: multiplication and division before addition and subtraction, with parentheses overriding precedence.
+4. THE Expression_Evaluator SHALL support unary minus for negative numbers at the start of an expression or after an opening parenthesis (e.g. `-5+3`, `(-5+3)`).
+5. THE Expression_Evaluator SHALL reject any characters outside the set: digits (`0-9`), decimal separator (`.` or `,`), operators (`+`, `-`, `*`, `/`), parentheses (`(`, `)`), and whitespace.
+
+### Requirement 4: Locale-Aware Decimal Separators
+
+**User Story:** As a user in a locale that uses comma as a decimal separator, I want the expression evaluator to correctly interpret my input, so that `10,50+2,25` evaluates to `12.75`.
+
+#### Acceptance Criteria
+
+1. THE Expression_Evaluator SHALL accept both `.` and `,` as decimal separators in numeric literals within expressions.
+2. WHEN the expression contains commas used as decimal separators, THE Expression_Evaluator SHALL interpret each comma as a decimal point for the immediately surrounding digits.
+3. THE Expression_Evaluator SHALL NOT interpret a comma as a thousands separator; each comma is treated as a decimal separator.
+
+### Requirement 5: Invalid Expression Handling
+
+**User Story:** As a user, I want clear feedback when I enter a malformed expression, so that I know what to fix before the form can be submitted.
+
+#### Acceptance Criteria
+
+1. IF the Amount_Input contains an Arithmetic_Expression with syntax errors (unbalanced parentheses, consecutive operators, trailing operators, empty parentheses), THEN THE Amount_Input SHALL display a validation error message indicating the expression is invalid.
+2. IF the Amount_Input contains an invalid expression on form submission, THEN THE Amount_Schema SHALL reject the value and block form submission.
+3. IF an Arithmetic_Expression produces a division by zero, THEN THE Expression_Evaluator SHALL treat the expression as invalid and THE Amount_Input SHALL display a validation error.
+4. IF an Arithmetic_Expression evaluates to a non-finite number (Infinity, NaN), THEN THE Expression_Evaluator SHALL treat the expression as invalid.
+
+### Requirement 6: Expression Evaluator as a Pure Utility
+
+**User Story:** As a developer, I want the expression evaluator to be a standalone pure function with no side effects, so that it is easy to test with property-based tests and reuse across the codebase.
+
+#### Acceptance Criteria
+
+1. THE Expression_Evaluator SHALL be implemented as a pure function that takes a string input and returns either a numeric result or an error indicator.
+2. THE Expression_Evaluator SHALL not depend on DOM APIs, React state, or any external service.
+3. THE Expression_Evaluator SHALL include a pretty-printer function that formats a parsed expression tree back into a canonical string representation.
+4. FOR ALL valid Arithmetic_Expressions, parsing then pretty-printing then parsing SHALL produce an equivalent expression tree (round-trip property).
+
+### Requirement 7: Integration with Expense and Payment Forms
+
+**User Story:** As a user, I want expression evaluation to work in both the expense form and the payment form amount fields, so that I have a consistent experience across the app.
+
+#### Acceptance Criteria
+
+1. WHEN the user enters an Arithmetic_Expression in the expense form amount field, THE Amount_Input SHALL evaluate the expression following the same rules as described in Requirement 1.
+2. WHEN the user enters an Arithmetic_Expression in the payment form amount field, THE Amount_Input SHALL evaluate the expression following the same rules as described in Requirement 1.
+3. THE Amount_Input SHALL preserve the existing currency symbol prefix, currency selector, and input group styling while supporting expressions.
+4. WHILE the user is actively typing an expression (field is focused), THE Amount_Input SHALL display the raw expression text without attempting evaluation.
+
+### Requirement 8: Input Affordance
+
+**User Story:** As a user, I want a visual hint that the amount field supports expressions, so that I can discover this feature without documentation.
+
+#### Acceptance Criteria
+
+1. THE Amount_Input SHALL update its placeholder text to hint at expression support (e.g. `0.00 or 10+5`).
+2. THE Amount_Input SHALL change its `inputMode` from `decimal` to `text` to allow entry of operator characters on mobile keyboards.

--- a/.kiro/specs/expense-amount-math-expressions/tasks.md
+++ b/.kiro/specs/expense-amount-math-expressions/tasks.md
@@ -1,0 +1,124 @@
+# Implementation Plan: Expense Amount Math Expressions
+
+## Overview
+
+Implement arithmetic expression evaluation in the expense and payment amount fields. Users can type expressions like `12+4.50`, `100/3`, or `(50+25)*2` directly into the amount input. The expression is evaluated on blur or form submission. The implementation follows a bottom-up approach: pure evaluator module → unit/property tests → schema integration → UI component update → i18n.
+
+## Tasks
+
+- [x] 1. Implement the pure expression evaluator module
+  - [x] 1.1 Create `src/lib/math-expression.ts` with AST types, tokenizer, recursive-descent parser, evaluator, prettyPrint, and isExpression
+    - Define `ExprNode` discriminated union types (`NumberNode`, `UnaryNode`, `BinaryNode`)
+    - Define `EvalResult` discriminated union (`EvalSuccess | EvalError`)
+    - Implement `tokenize(input: string)` — converts input string into a token array (numbers, operators, parens), handling both `.` and `,` as decimal separators
+    - Implement `parse(input: string)` — recursive-descent parser following the EBNF grammar: `Expression → Term (('+' | '-') Term)*`, `Term → Factor (('*' | '/') Factor)*`, `Factor → '-' Factor | Atom`, `Atom → '(' Expression ')' | Number`
+    - Implement `evaluate(input: string): EvalResult` — parses then tree-walks the AST; returns `{ ok: false }` for division by zero, non-finite results, or syntax errors
+    - Implement `prettyPrint(node: ExprNode): string` — canonical string representation with minimal parentheses based on operator precedence
+    - Implement `isExpression(input: string): boolean` — fast regex check for operator characters (excluding leading unary minus)
+    - Reject characters outside the allowed set: digits, `.`, `,`, `+`, `-`, `*`, `/`, `(`, `)`, whitespace
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, 4.2, 4.3, 5.3, 5.4, 6.1, 6.2, 6.3_
+
+  - [x] 1.2 Write unit tests for the expression evaluator in `src/lib/math-expression.test.ts`
+    - Test basic arithmetic: `"12+4.50"` → `16.5`, `"100/3"` → `33.333...`, `"(50+25)*2"` → `150`
+    - Test unary minus: `"-5+3"` → `-2`, `"(-5+3)"` → `-2`
+    - Test operator precedence: `"2+3*4"` → `14`, `"(2+3)*4"` → `20`
+    - Test comma decimals: `"10,50+2,25"` → `12.75`
+    - Test whitespace handling: `" 5 + 3 "` → `8`
+    - Test error cases: division by zero (`"10/0"`), unbalanced parens (`"(5+3"`), trailing operator (`"5+"`), empty parens (`"()"`), consecutive operators (`"5++3"`), invalid characters (`"5+abc"`)
+    - Test edge cases: large numbers (`"99999*99999"`), deeply nested parens, single number passthrough
+    - Test `isExpression` correctly identifies expressions vs plain numbers
+    - Test `prettyPrint` produces canonical output
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, 5.1, 5.3, 5.4, 6.3_
+
+  - [x] 1.3 Write property-based tests in `src/lib/math-expression.property.test.ts`
+    - **Property 1: Evaluator Arithmetic Correctness** — Generate random ASTs (depth ≤ 4) using fast-check arbitraries, prettyPrint to string, evaluate, compare to reference JS computation on the AST (within floating-point tolerance). Avoid division by zero in generated trees.
+    - **Validates: Requirements 1.2, 3.1, 3.2, 3.3, 3.4**
+    - **Property 2: Parse/Print Round-Trip** — Generate random ASTs, prettyPrint → parse → compare structural AST equality.
+    - **Validates: Requirements 6.3, 6.4**
+    - **Property 3: Locale Decimal Equivalence** — Generate expressions with `.` decimals, create `,` variant, compare evaluate results are equal.
+    - **Validates: Requirements 4.1, 4.2**
+    - **Property 4: Invalid Input Rejection** — Generate strings with invalid characters and structurally invalid expressions, verify `evaluate` returns `{ ok: false }`.
+    - **Validates: Requirements 3.5, 5.1, 5.2, 5.3, 5.4**
+    - Configure `numRuns: 200` for each property
+    - _Requirements: 6.1, 6.2, 6.4_
+
+- [x] 2. Checkpoint - Core evaluator tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 3. Integrate expression evaluation into Zod schemas
+  - [x] 3.1 Add `enforceExpressionPattern` helper to `src/lib/currency-input.ts`
+    - Export `enforceExpressionPattern(value: string): string` that strips characters not in the set: digits, `.`, `,`, `+`, `-`, `*`, `/`, `(`, `)`, whitespace
+    - _Requirements: 3.5, 5.1_
+
+  - [x] 3.2 Update `src/lib/schemas.ts` with expression-aware amount transforms
+    - Import `evaluate` and `isExpression` from `@/lib/math-expression`
+    - Create shared `expressionToNumber(value: string, ctx: z.RefinementCtx): number` helper that: uses `isExpression` for fast-path detection, calls `evaluate` for expression strings, falls back to `Number()` for plain numbers, adds `invalidExpression` issue code on evaluation failure
+    - Replace the inline `.transform()` in `expenseFormSchema.amount` to use `expressionToNumber`
+    - Replace the inline `.transform()` in `paymentAmountSchema` to use `expressionToNumber`
+    - _Requirements: 2.1, 2.2, 5.2_
+
+  - [x] 3.3 Write property-based test for schema consistency in `src/lib/math-expression.property.test.ts`
+    - **Property 5: Schema Expression Evaluation Consistency** — Generate valid expression strings, pass through the Zod amount schema transform, verify result equals `evaluate(expr).value`.
+    - **Validates: Requirements 2.1, 2.2**
+    - _Requirements: 2.1, 2.2_
+
+- [x] 4. Update the CurrencyAmountInput component
+  - [x] 4.1 Modify `src/components/currency-amount-input.tsx` to evaluate expressions on blur
+    - Import `evaluate` and `isExpression` from `@/lib/math-expression`
+    - Import `enforceExpressionPattern` from `@/lib/currency-input`
+    - Update `onBlur` handler: if `isExpression(draft)`, call `evaluate(draft)`; if `result.ok`, call `onValueChange(String(result.value))`; if not ok, propagate raw draft for schema validation to catch
+    - Update `onChange` handler: detect if input contains operator characters; if so, use `enforceExpressionPattern` instead of `enforceCurrencyPattern`
+    - Change `inputMode` from `"decimal"` to `"text"` to allow operator entry on mobile keyboards
+    - Update `placeholder` to include expression hint (e.g., `"0.00 or 10+5"`) using a new helper or inline logic combining `getCurrencyInputPlaceholder` with expression hint
+    - Preserve existing behavior: while focused, display raw draft text; on blur with plain number, existing formatting applies
+    - _Requirements: 1.1, 1.2, 7.1, 7.2, 7.3, 7.4, 8.1, 8.2_
+
+  - [x] 4.2 Write unit tests for `CurrencyAmountInput` expression behavior
+    - Test that `inputMode` is `"text"`
+    - Test that placeholder includes expression hint text
+    - Test that onBlur with a valid expression calls `onValueChange` with the evaluated numeric result
+    - Test that onBlur with an invalid expression propagates the raw string
+    - Test that focused state shows raw draft without evaluation
+    - Test that plain numbers continue to work as before (no regression)
+    - _Requirements: 1.1, 1.2, 7.4, 8.1, 8.2_
+
+- [x] 5. Checkpoint - Schema and component tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 6. Add i18n messages and finalize integration
+  - [x] 6.1 Add `invalidExpression` error message to locale files
+    - Add `"invalidExpression": "Invalid expression. Use numbers and +, -, *, / operators."` under the appropriate namespace in `messages/en-US.json`
+    - Add translated equivalent to other locale files (e.g., `messages/de-DE.json`)
+    - _Requirements: 5.1, 5.2_
+
+  - [x] 6.2 Wire error message display in form validation feedback
+    - Ensure the `invalidExpression` message key from the schema is picked up by the form's error display logic (verify `ExpenseForm` and `PaymentForm` render the message via `next-intl` translation)
+    - _Requirements: 5.1, 5.2, 7.1, 7.2_
+
+- [x] 7. Final checkpoint - All tests pass and types check
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- All tasks are mandatory — property-based tests are critical for a pure arithmetic utility
+- Each task references specific requirements for traceability
+- The evaluator is intentionally pure (no DOM, no React, no I/O) enabling exhaustive property-based testing with `fast-check`
+- The recursive-descent parser produces an AST as a plain data structure, enabling structural property tests
+- No database schema changes are required — expressions are always evaluated to numbers before persistence
+- The `enforceExpressionPattern` filter provides defense-in-depth at the input layer, while the evaluator's character allowlist provides the authoritative rejection
+- Rounding for currency precision is handled by the existing `formatCurrencyInputValue` (via `Intl.NumberFormat`) after evaluation
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["1.2", "1.3"] },
+    { "id": 2, "tasks": ["3.1", "3.2"] },
+    { "id": 3, "tasks": ["3.3", "4.1"] },
+    { "id": 4, "tasks": ["4.2", "6.1"] },
+    { "id": 5, "tasks": ["6.2"] }
+  ]
+}
+```

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Una altra participant ja té el mateix nom",
     "titleRequired": "Si us plau, afegeix un títol",
     "invalidNumber": "Número invàlid",
+    "invalidExpression": "Expressió no vàlida. Usa nombres i els operadors +, -, *, /.",
     "amountRequired": "Cal introduïr un import",
     "amountNotZero": "L'import no por ser zero.",
     "amountTenMillion": "L'import ha de ser inferior a 10.000.000.",
@@ -1097,5 +1098,8 @@
       "close-in-date": "Dates properes",
       "same-category": "Mateixa categoria"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "o 10+5"
   }
 }

--- a/messages/cs-CZ.json
+++ b/messages/cs-CZ.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Jiný účastník už toto jméno má.",
     "titleRequired": "Zadejte prosím název.",
     "invalidNumber": "Neplatné číslo.",
+    "invalidExpression": "Neplatný výraz. Použijte čísla a operátory +, -, *, /.",
     "amountRequired": "Musíte zadat částku.",
     "amountNotZero": "Částka nesmí být nula.",
     "amountTenMillion": "Částka musí být nižší než 10 000 000.",
@@ -1097,5 +1098,8 @@
       "close-in-date": "Blízké datum",
       "same-category": "Stejná kategorie"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "nebo 10+5"
   }
 }

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Der Name ist bereits an ein anderes Gruppenmitglied vergeben.",
     "titleRequired": "Bitte gib einen Titel an.",
     "invalidNumber": "Zahl nicht valide.",
+    "invalidExpression": "Ungültiger Ausdruck. Verwende Zahlen und +, -, *, / Operatoren.",
     "amountRequired": "Du musst einen Betrag angeben.",
     "amountNotZero": "Der Betrag darf nicht 0 sein.",
     "amountTenMillion": "Der Betrag muss kleiner als 10.000.000 sein.",
@@ -1097,5 +1098,8 @@
       "close-in-date": "Nahes Datum",
       "same-category": "Gleiche Kategorie"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "oder 10+5"
   }
 }

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -594,6 +594,7 @@
     "titleRequired": "Please enter a title.",
     "paymentCategoryNotAllowed": "Payment is not a valid category for expenses.",
     "invalidNumber": "Invalid number.",
+    "invalidExpression": "Invalid expression. Use numbers and +, -, *, / operators.",
     "amountRequired": "You must enter an amount.",
     "amountNotZero": "The amount must not be zero.",
     "amountTenMillion": "The amount must be lower than 10,000,000.",
@@ -1252,5 +1253,8 @@
       "close-in-date": "Close in date",
       "same-category": "Same category"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "or 10+5"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Otro participante ya tiene este nombre",
     "titleRequired": "Por favor, introduzca un título",
     "invalidNumber": "Número inválido",
+    "invalidExpression": "Expresión inválida. Usa números y los operadores +, -, *, /.",
     "amountRequired": "Debe introducir un importe",
     "amountNotZero": "El importe no debe ser cero.",
     "amountTenMillion": "El importe debe ser inferior a 10.000.000.",
@@ -1097,5 +1098,8 @@
       "close-in-date": "Fechas cercanas",
       "same-category": "Misma categoría"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "o 10+5"
   }
 }

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Tämä nimi on jo toisella osallistujalla.",
     "titleRequired": "Otsikko puuttuu.",
     "invalidNumber": "Epäkelpo numero.",
+    "invalidExpression": "Virheellinen lauseke. Käytä numeroita ja operaattoreita +, -, *, /.",
     "amountRequired": "Summa puuttuu.",
     "amountNotZero": "Summa ei voi olla nolla.",
     "amountTenMillion": "Summan pitää olla pienempi kuin 10 000 000.",
@@ -1097,5 +1098,8 @@
       "close-in-date": "Läheiset päivämäärät",
       "same-category": "Sama kategoria"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "tai 10+5"
   }
 }

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Un autre participant a déjà ce nom.",
     "titleRequired": "Veuillez entrer un titre.",
     "invalidNumber": "Nombre invalide.",
+    "invalidExpression": "Expression invalide. Utilisez des nombres et les opérateurs +, -, *, /.",
     "amountRequired": "Vous devez entrer un montant.",
     "amountNotZero": "Le montant ne doit pas être zéro.",
     "amountTenMillion": "Le montant doit être inférieur à 10 000 000.",
@@ -1097,5 +1098,8 @@
       "close-in-date": "Dates proches",
       "same-category": "Même catégorie"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "ou 10+5"
   }
 }

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Un altro partecipante ha già questo nome.",
     "titleRequired": "Inserisci un titolo.",
     "invalidNumber": "Numero invalido.",
+    "invalidExpression": "Espressione non valida. Usa numeri e gli operatori +, -, *, /.",
     "amountRequired": "Devi inserire un importo.",
     "amountNotZero": "L'importo non deve essere zero.",
     "amountTenMillion": "L'importo deve essere inferiore a 10.000.000.",
@@ -1097,5 +1098,8 @@
       "close-in-date": "Date vicine",
       "same-category": "Stessa categoria"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "o 10+5"
   }
 }

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "別の参加者がすでにこの名前を使用しています。",
     "titleRequired": "タイトルを入力してください。",
     "invalidNumber": "無効な数字です。",
+    "invalidExpression": "無効な式です。数字と +, -, *, / 演算子を使用してください。",
     "amountRequired": "金額を入力する必要があります。",
     "amountNotZero": "金額はゼロであってはなりません。",
     "amountTenMillion": "金額は10,000,000未満である必要があります。",
@@ -1094,5 +1095,8 @@
       "close-in-date": "近い日付",
       "same-category": "同じカテゴリ"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "または 10+5"
   }
 }

--- a/messages/nl-NL.json
+++ b/messages/nl-NL.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Er is al een deelnemer met deze naam.",
     "titleRequired": "Vul een titel in.",
     "invalidNumber": "Ongeldig getal.",
+    "invalidExpression": "Ongeldige uitdrukking. Gebruik getallen en +, -, *, / operatoren.",
     "amountRequired": "Vul een bedrag in.",
     "amountNotZero": "Het bedrag moet hoger zijn dan 0.",
     "amountTenMillion": "Het bedrag mag niet hoger zijn dan 10,000,000.",
@@ -1094,5 +1095,8 @@
       "close-in-date": "Dichtbijgelegen data",
       "same-category": "Zelfde categorie"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "of 10+5"
   }
 }

--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Ta nazwa jest już zajęta.",
     "titleRequired": "Podaj tytuł.",
     "invalidNumber": "Niewłaściwa liczba.",
+    "invalidExpression": "Nieprawidłowe wyrażenie. Użyj liczb i operatorów +, -, *, /.",
     "amountRequired": "Należy wprowadzić kwotę.",
     "amountNotZero": "Kwota nie może być zerem.",
     "amountTenMillion": "Kwota musi być niższa niż 10 000 000.",
@@ -1094,5 +1095,8 @@
       "close-in-date": "Bliskie daty",
       "same-category": "Ta sama kategoria"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "lub 10+5"
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Outro participante já tem este nome.",
     "titleRequired": "Por favor, insira um título.",
     "invalidNumber": "Número inválido.",
+    "invalidExpression": "Expressão inválida. Use números e operadores +, -, *, /.",
     "amountRequired": "Você deve inserir um valor.",
     "amountNotZero": "O valor não deve ser zero.",
     "amountTenMillion": "O valor deve ser inferior a 10.000.000.",
@@ -1099,5 +1100,8 @@
       "close-in-date": "Datas próximas",
       "same-category": "Mesma categoria"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "ou 10+5"
   }
 }

--- a/messages/pt-PT.json
+++ b/messages/pt-PT.json
@@ -594,6 +594,7 @@
     "titleRequired": "Por favor, introduz um título.",
     "paymentCategoryNotAllowed": "Pagamento não é uma categoria válida para despesas.",
     "invalidNumber": "Número inválido.",
+    "invalidExpression": "Expressão inválida. Use números e operadores +, -, *, /.",
     "amountRequired": "Tens de introduzir um valor.",
     "amountNotZero": "O valor não pode ser zero.",
     "amountTenMillion": "O valor deve ser inferior a 10.000.000.",
@@ -1241,5 +1242,8 @@
       "close-in-date": "Datas próximas",
       "same-category": "Mesma categoria"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "ou 10+5"
   }
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Un alt membru are deja acest nume.",
     "titleRequired": "Vă rugăm să introduceți un titlu.",
     "invalidNumber": "Număr invalid.",
+    "invalidExpression": "Expresie invalidă. Folosiți numere și operatorii +, -, *, /.",
     "amountRequired": "Trebuie să introduceți o sumă.",
     "amountNotZero": "Suma nu trebuie să fie zero.",
     "amountTenMillion": "Suma trebuie să fie mai mică de 10,000,000.",
@@ -1094,5 +1095,8 @@
       "close-in-date": "Date apropiate",
       "same-category": "Aceeași categorie"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "sau 10+5"
   }
 }

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Участник с таким именем уже существует.",
     "titleRequired": "Пожалуйста, введите название.",
     "invalidNumber": "Неверное число.",
+    "invalidExpression": "Неверное выражение. Используйте числа и операторы +, -, *, /.",
     "amountRequired": "Пожалуйста, введите сумму.",
     "amountNotZero": "Сумма не может быть нулевой.",
     "amountTenMillion": "Сумма должна быть меньше 10 000 000.",
@@ -1094,5 +1095,8 @@
       "close-in-date": "Близкие даты",
       "same-category": "Та же категория"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "или 10+5"
   }
 }

--- a/messages/tr-TR.json
+++ b/messages/tr-TR.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Başka bir katılımcı zaten bu ada sahip.",
     "titleRequired": "Lütfen bir başlık girin.",
     "invalidNumber": "Geçersiz numara.",
+    "invalidExpression": "Geçersiz ifade. Sayılar ve +, -, *, / operatörlerini kullanın.",
     "amountRequired": "Bir tutar girmelisiniz.",
     "amountNotZero": "Tutar sıfır olamaz.",
     "amountTenMillion": "Tutar 10.000.000'dan düşük olmalı.",
@@ -1094,5 +1095,8 @@
       "close-in-date": "Yakın tarihler",
       "same-category": "Aynı kategori"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "veya 10+5"
   }
 }

--- a/messages/ua-UA.json
+++ b/messages/ua-UA.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "Інший учасник уже має це ім'я",
     "titleRequired": "Будь ласка, введіть назву",
     "invalidNumber": "Невірний номер",
+    "invalidExpression": "Невірний вираз. Використовуйте числа та оператори +, -, *, /.",
     "amountRequired": "Необхідно ввести суму",
     "amountNotZero": "Сума не повинна дорівнювати нулю",
     "amountTenMillion": "Сума повинна бути меншою за 10,000,000",
@@ -1094,5 +1095,8 @@
       "close-in-date": "Близькі дати",
       "same-category": "Та сама категорія"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "або 10+5"
   }
 }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "此名字已被另一位群组成员占用。",
     "titleRequired": "请输入标题。",
     "invalidNumber": "无效数值。",
+    "invalidExpression": "无效的表达式。请使用数字和 +、-、*、/ 运算符。",
     "amountRequired": "你必须输入一个金额。",
     "amountNotZero": "金额不可以为0。",
     "amountTenMillion": "金额必须小于10,000,000。",
@@ -1094,5 +1095,8 @@
       "close-in-date": "日期接近",
       "same-category": "相同类别"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "或 10+5"
   }
 }

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -526,6 +526,7 @@
     "duplicateParticipantName": "此名稱已被使用",
     "titleRequired": "請輸入標題。",
     "invalidNumber": "數值無效。",
+    "invalidExpression": "無效的運算式。請使用數字和 +、-、*、/ 運算子。",
     "amountRequired": "必須輸入一個金額。",
     "amountNotZero": "金額不可為 0。",
     "amountTenMillion": "金額需小於 10,000,000。",
@@ -1094,5 +1095,8 @@
       "close-in-date": "日期接近",
       "same-category": "相同類別"
     }
+  },
+  "CurrencyAmountInput": {
+    "expressionHint": "或 10+5"
   }
 }

--- a/src/components/__tests__/currency-amount-input.test.tsx
+++ b/src/components/__tests__/currency-amount-input.test.tsx
@@ -1,0 +1,139 @@
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { CurrencyAmountInput } from '../currency-amount-input'
+
+import type { Currency } from '@/lib/currency'
+
+// Mock next-intl
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const messages: Record<string, string> = {
+      expressionHint: 'or 10+5',
+    }
+    return messages[key] ?? key
+  },
+}))
+
+const usdCurrency: Currency = {
+  code: 'USD',
+  name: 'US Dollar',
+  name_plural: 'US dollars',
+  symbol: '$',
+  symbol_native: '$',
+  decimal_digits: 2,
+  rounding: 0,
+}
+
+const defaultProps = {
+  value: undefined as number | string | undefined | null,
+  onValueChange: jest.fn(),
+  currency: usdCurrency,
+  locale: 'en-US',
+}
+
+describe('CurrencyAmountInput — expression behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  /**
+   * Validates: Requirement 8.2
+   */
+  it('sets inputMode to "text"', () => {
+    render(<CurrencyAmountInput {...defaultProps} />)
+
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveAttribute('inputmode', 'text')
+  })
+
+  /**
+   * Validates: Requirement 8.1
+   */
+  it('placeholder includes expression hint text', () => {
+    render(<CurrencyAmountInput {...defaultProps} />)
+
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveAttribute(
+      'placeholder',
+      expect.stringContaining('or 10+5'),
+    )
+  })
+
+  /**
+   * Validates: Requirements 1.1, 7.4
+   */
+  it('onBlur with a valid expression calls onValueChange with evaluated numeric result', () => {
+    const onValueChange = jest.fn()
+    render(
+      <CurrencyAmountInput {...defaultProps} onValueChange={onValueChange} />,
+    )
+
+    const input = screen.getByRole('textbox')
+
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '10+5' } })
+    fireEvent.blur(input)
+
+    // The last call to onValueChange on blur should be the evaluated result
+    const calls = onValueChange.mock.calls
+    const lastCall = calls[calls.length - 1]
+    expect(lastCall[0]).toBe('15')
+  })
+
+  /**
+   * Validates: Requirements 1.1, 5.1
+   */
+  it('onBlur with an invalid expression propagates the raw string', () => {
+    const onValueChange = jest.fn()
+    render(
+      <CurrencyAmountInput {...defaultProps} onValueChange={onValueChange} />,
+    )
+
+    const input = screen.getByRole('textbox')
+
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '10+' } })
+    fireEvent.blur(input)
+
+    // On blur with invalid expression, the raw draft is propagated
+    const calls = onValueChange.mock.calls
+    const lastCall = calls[calls.length - 1]
+    expect(lastCall[0]).toBe('10+')
+  })
+
+  /**
+   * Validates: Requirement 7.4
+   */
+  it('focused state shows raw draft without evaluation', () => {
+    render(<CurrencyAmountInput {...defaultProps} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '10+5' } })
+
+    // While focused, input shows raw expression, not evaluated result
+    expect(input.value).toBe('10+5')
+  })
+
+  /**
+   * Validates: Requirement 1.2
+   */
+  it('plain numbers continue to work as before (no regression)', () => {
+    const onValueChange = jest.fn()
+    render(
+      <CurrencyAmountInput {...defaultProps} onValueChange={onValueChange} />,
+    )
+
+    const input = screen.getByRole('textbox')
+
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: '42.50' } })
+    fireEvent.blur(input)
+
+    // Plain number is not an expression, so onChange propagated it directly.
+    // On blur, isExpression('42.50') is false, so no expression evaluation occurs.
+    // The onValueChange from onChange should have been called with the plain number.
+    expect(onValueChange).toHaveBeenCalledWith('42.50')
+  })
+})

--- a/src/components/currency-amount-input.tsx
+++ b/src/components/currency-amount-input.tsx
@@ -4,11 +4,14 @@ import { InputGroupInput } from '@/components/ui/input-group'
 import { Currency } from '@/lib/currency'
 import {
   enforceCurrencyPattern,
+  enforceExpressionPattern,
   formatCurrencyInputValue,
   getCurrencyInputPlaceholder,
   valueToCurrencyDraft,
 } from '@/lib/currency-input'
+import { evaluate, isExpression } from '@/lib/math-expression'
 import { cn } from '@/lib/utils'
+import { useTranslations } from 'next-intl'
 import { ComponentProps, forwardRef, useState } from 'react'
 
 type CurrencyAmountInputProps = Omit<
@@ -39,10 +42,13 @@ export const CurrencyAmountInput = forwardRef<
 ) {
   const [isFocused, setIsFocused] = useState(false)
   const [draft, setDraft] = useState('')
+  const t = useTranslations('CurrencyAmountInput')
 
   const displayValue = isFocused
     ? draft
     : formatCurrencyInputValue(value, locale, currency.decimal_digits)
+
+  const placeholder = `${getCurrencyInputPlaceholder(locale, currency.decimal_digits)} ${t('expressionHint')}`
 
   return (
     <InputGroupInput
@@ -50,8 +56,8 @@ export const CurrencyAmountInput = forwardRef<
       ref={ref}
       className={cn('text-base tabular-nums', className)}
       type="text"
-      inputMode="decimal"
-      placeholder={getCurrencyInputPlaceholder(locale, currency.decimal_digits)}
+      inputMode="text"
+      placeholder={placeholder}
       value={displayValue}
       onFocus={(event) => {
         setIsFocused(true)
@@ -62,11 +68,27 @@ export const CurrencyAmountInput = forwardRef<
       }}
       onBlur={(event) => {
         setIsFocused(false)
+
+        if (isExpression(draft)) {
+          const result = evaluate(draft)
+          if (result.ok) {
+            onValueChange(String(result.value))
+          } else {
+            // Propagate raw draft for schema validation to catch
+            onValueChange(draft)
+          }
+        }
+
         setDraft('')
         onBlur?.(event)
       }}
       onChange={(event) => {
-        const normalized = enforceCurrencyPattern(event.target.value)
+        const raw = event.target.value
+        // If input contains operator characters, use expression-aware filtering
+        const normalized =
+          /[+*/()]/.test(raw) || (raw.includes('-') && !raw.startsWith('-'))
+            ? enforceExpressionPattern(raw)
+            : enforceCurrencyPattern(raw)
         setDraft(normalized)
         onValueChange(normalized)
       }}

--- a/src/lib/currency-input.ts
+++ b/src/lib/currency-input.ts
@@ -58,3 +58,10 @@ export function getCurrencyDisplaySymbol(currency: Currency): string {
 export function formatObtainedExchangeRate(rate: number): string {
   return rate.toFixed(2)
 }
+
+/**
+ * Allow characters valid in arithmetic expressions:
+ * digits, decimal separators (. ,), operators (+ - * /), parentheses, whitespace.
+ */
+export const enforceExpressionPattern = (value: string): string =>
+  value.replace(/[^\d.,+\-*/() ]/g, '')

--- a/src/lib/math-expression.property.test.ts
+++ b/src/lib/math-expression.property.test.ts
@@ -1,0 +1,382 @@
+import type { ExprNode } from '@/lib/math-expression'
+import { evaluate, parse, prettyPrint } from '@/lib/math-expression'
+import { expenseFormSchema } from '@/lib/schemas'
+import fc from 'fast-check'
+
+/**
+ * Property-based tests for the math expression evaluator.
+ *
+ * Feature: expense-amount-math-expressions
+ *
+ * Validates: Requirements 1.2, 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, 4.2, 5.1, 5.2, 5.3, 5.4, 6.3, 6.4
+ */
+
+// --- Generators ---
+
+function arbExprNode(maxDepth: number): fc.Arbitrary<ExprNode> {
+  const arbNumber = fc
+    .double({ min: 0.01, max: 9999, noNaN: true, noDefaultInfinity: true })
+    .map((v) => Math.round(v * 100) / 100)
+    .map((value): ExprNode => ({ type: 'number', value }))
+
+  if (maxDepth <= 0) return arbNumber
+
+  const arbOperator = fc.constantFrom('+', '-', '*', '/') as fc.Arbitrary<
+    '+' | '-' | '*' | '/'
+  >
+
+  const arbBinary = fc
+    .tuple(arbExprNode(maxDepth - 1), arbOperator, arbExprNode(maxDepth - 1))
+    .filter(([_, op, right]) => {
+      if (op === '/') {
+        if (right.type === 'number') return right.value !== 0
+      }
+      return true
+    })
+    .map(
+      ([left, operator, right]): ExprNode => ({
+        type: 'binary',
+        operator,
+        left,
+        right,
+      }),
+    )
+
+  const arbUnary = arbExprNode(maxDepth - 1).map(
+    (operand): ExprNode => ({ type: 'unary', operator: '-', operand }),
+  )
+
+  return fc.oneof(
+    { weight: 3, arbitrary: arbNumber },
+    { weight: 4, arbitrary: arbBinary },
+    { weight: 1, arbitrary: arbUnary },
+  )
+}
+
+// --- Reference evaluator ---
+
+function referenceEval(node: ExprNode): number {
+  switch (node.type) {
+    case 'number':
+      return node.value
+    case 'unary':
+      return -referenceEval(node.operand)
+    case 'binary': {
+      const l = referenceEval(node.left)
+      const r = referenceEval(node.right)
+      switch (node.operator) {
+        case '+':
+          return l + r
+        case '-':
+          return l - r
+        case '*':
+          return l * r
+        case '/':
+          return l / r
+      }
+    }
+  }
+}
+
+// --- AST comparison with floating-point tolerance ---
+
+function astEqual(a: ExprNode, b: ExprNode): boolean {
+  if (a.type !== b.type) return false
+  switch (a.type) {
+    case 'number':
+      return Math.abs(a.value - (b as typeof a).value) < 1e-9
+    case 'unary':
+      return astEqual(a.operand, (b as typeof a).operand)
+    case 'binary': {
+      const bb = b as typeof a
+      return (
+        a.operator === bb.operator &&
+        astEqual(a.left, bb.left) &&
+        astEqual(a.right, bb.right)
+      )
+    }
+  }
+}
+
+// --- Property Tests ---
+
+describe('Feature: expense-amount-math-expressions, Property 1: Evaluator Arithmetic Correctness', () => {
+  /**
+   * Validates: Requirements 1.2, 3.1, 3.2, 3.3, 3.4
+   *
+   * For any valid AST (depth ≤ 4), prettyPrint to string then evaluate should
+   * produce a result equal to the reference JS computation on the AST
+   * (within floating-point tolerance).
+   */
+  it('evaluate(prettyPrint(ast)) equals reference JS computation for random ASTs', () => {
+    fc.assert(
+      fc.property(arbExprNode(4), (ast) => {
+        const ref = referenceEval(ast)
+
+        // Skip non-finite reference results (division by zero in subtrees)
+        if (!Number.isFinite(ref)) return true
+
+        const printed = prettyPrint(ast)
+        const result = evaluate(printed)
+
+        if (!result.ok) {
+          // If evaluator rejects, it should only be for non-finite results
+          // which we already filtered above, so this is unexpected
+          return false
+        }
+
+        // Compare with relative tolerance for floating-point
+        if (Math.abs(ref) < 1e-10) {
+          return Math.abs(result.value - ref) < 1e-6
+        }
+        return Math.abs((result.value - ref) / ref) < 1e-9
+      }),
+      { numRuns: 200 },
+    )
+  })
+})
+
+describe('Feature: expense-amount-math-expressions, Property 2: Parse/Print Round-Trip', () => {
+  /**
+   * Validates: Requirements 6.3, 6.4
+   *
+   * For any valid AST, prettyPrint → parse → prettyPrint should produce the
+   * same canonical string (idempotent round-trip). This validates that:
+   * 1. prettyPrint always produces parseable output
+   * 2. The canonical form is stable (round-tripping converges)
+   */
+  it('prettyPrint(parse(prettyPrint(ast))) equals prettyPrint(ast) — canonical form is idempotent', () => {
+    fc.assert(
+      fc.property(arbExprNode(4), (ast) => {
+        const printed = prettyPrint(ast)
+        const parsed = parse(printed)
+
+        if (!parsed.ok) {
+          // prettyPrint should always produce parseable output
+          return false
+        }
+
+        const reprinted = prettyPrint(parsed.ast)
+
+        // The canonical form should be stable: re-printing the parsed AST
+        // should give the same string
+        return printed === reprinted
+      }),
+      { numRuns: 200 },
+    )
+  })
+
+  /**
+   * Validates: Requirements 6.3, 6.4
+   *
+   * For any valid AST, prettyPrint → parse → evaluate should give the same
+   * numeric result as directly evaluating the original AST. This ensures
+   * the round-trip preserves semantics.
+   */
+  it('parse(prettyPrint(ast)) preserves evaluation semantics', () => {
+    fc.assert(
+      fc.property(arbExprNode(4), (ast) => {
+        const ref = referenceEval(ast)
+        if (!Number.isFinite(ref)) return true
+
+        const printed = prettyPrint(ast)
+        const parsed = parse(printed)
+
+        if (!parsed.ok) return false
+
+        const parsedRef = referenceEval(parsed.ast)
+
+        if (Math.abs(ref) < 1e-10) {
+          return Math.abs(parsedRef - ref) < 1e-6
+        }
+        return Math.abs((parsedRef - ref) / ref) < 1e-9
+      }),
+      { numRuns: 200 },
+    )
+  })
+})
+
+describe('Feature: expense-amount-math-expressions, Property 3: Locale Decimal Equivalence', () => {
+  /**
+   * Validates: Requirements 4.1, 4.2
+   *
+   * For any expression with `.` decimal separators, replacing `.` with `,`
+   * in numeric literals should produce the same evaluation result.
+   */
+  it('expressions with comma decimals evaluate the same as dot decimals', () => {
+    fc.assert(
+      fc.property(arbExprNode(3), (ast) => {
+        const printed = prettyPrint(ast)
+
+        // Only test if the expression contains decimal points
+        if (!printed.includes('.')) return true
+
+        // Replace dots in numeric literals with commas
+        // Dots only appear in numeric literals in prettyPrint output
+        const commaVariant = printed.replace(/(\d)\.(\d)/g, '$1,$2')
+
+        const dotResult = evaluate(printed)
+        const commaResult = evaluate(commaVariant)
+
+        if (!dotResult.ok || !commaResult.ok) {
+          // Both should either succeed or fail
+          return dotResult.ok === commaResult.ok
+        }
+
+        // Results should be equal
+        if (Math.abs(dotResult.value) < 1e-10) {
+          return Math.abs(dotResult.value - commaResult.value) < 1e-6
+        }
+        return (
+          Math.abs((dotResult.value - commaResult.value) / dotResult.value) <
+          1e-9
+        )
+      }),
+      { numRuns: 200 },
+    )
+  })
+})
+
+describe('Feature: expense-amount-math-expressions, Property 4: Invalid Input Rejection', () => {
+  /**
+   * Validates: Requirements 3.5, 5.1, 5.2, 5.3, 5.4
+   *
+   * Strings with invalid characters or structurally invalid expressions
+   * should always be rejected by evaluate.
+   */
+  it('strings with invalid characters are rejected', () => {
+    const invalidChar = fc.constantFrom(
+      '@',
+      '#',
+      '$',
+      '!',
+      '&',
+      '=',
+      '?',
+      'a',
+      'b',
+      'c',
+      'x',
+      'y',
+      'z',
+      'A',
+      'B',
+      'C',
+    )
+
+    // Mix invalid chars with valid expression parts
+    const invalidInput = fc
+      .tuple(
+        fc.constantFrom('1', '2+3', '10*5', '(4+2)'),
+        fc.array(invalidChar, { minLength: 1, maxLength: 10 }),
+      )
+      .map(([valid, chars]) => valid + chars.join(''))
+
+    fc.assert(
+      fc.property(invalidInput, (input) => {
+        const result = evaluate(input)
+        return !result.ok
+      }),
+      { numRuns: 200 },
+    )
+  })
+
+  it('structurally invalid expressions are rejected', () => {
+    const structurallyInvalid = fc.constantFrom(
+      // Unbalanced parentheses
+      '(5+3',
+      '5+3)',
+      '((5+3)',
+      '(5+3))',
+      '(((1+2)',
+      // Trailing operators
+      '5+',
+      '3-',
+      '10*',
+      '7/',
+      '1+2+',
+      // Empty parentheses
+      '()',
+      '1+()',
+      '()+2',
+      // Consecutive operators (non-unary)
+      '5**3',
+      '5//3',
+      '5*/3',
+      '5/*3',
+      // Leading non-unary operators
+      '*5',
+      '/5',
+      '+',
+      '*',
+      '/',
+      // Just operators
+      '+-',
+      '++',
+      // Division by zero
+      '10/0',
+      '5/(3-3)',
+      '100/(0)',
+    )
+
+    fc.assert(
+      fc.property(structurallyInvalid, (input) => {
+        const result = evaluate(input)
+        return !result.ok
+      }),
+      { numRuns: 200 },
+    )
+  })
+})
+
+describe('Feature: expense-amount-math-expressions, Property 5: Schema Expression Evaluation Consistency', () => {
+  /**
+   * Validates: Requirements 2.1, 2.2
+   *
+   * For any valid expression string, passing it through the Zod amount schema
+   * transform should produce a numeric value equal to evaluate(expr).value.
+   */
+  it('Zod amount schema produces the same result as direct evaluate() for valid expressions', () => {
+    fc.assert(
+      fc.property(arbExprNode(3), (ast) => {
+        const ref = referenceEval(ast)
+        if (!Number.isFinite(ref)) return true
+        if (ref === 0) return true // skip zero since schema rejects it (amountNotZero)
+        if (ref < 0) return true // skip negative since paymentAmountSchema rejects it
+        if (ref > 10_000_000_00) return true // skip amounts exceeding max
+
+        const printed = prettyPrint(ast)
+        const evalResult = evaluate(printed)
+        if (!evalResult.ok) return true // skip if evaluator rejects (shouldn't happen for valid ASTs)
+
+        // Parse through the expense form schema's amount field
+        const schemaResult = expenseFormSchema.safeParse({
+          expenseDate: new Date(),
+          title: 'Test',
+          category: 0,
+          amount: printed,
+          paidBy: 'user1',
+          paidFor: [{ participant: 'user2', shares: '100' }],
+          splitMode: 'EVENLY',
+          saveDefaultSplittingOptions: false,
+          isReimbursement: false,
+        })
+
+        if (!schemaResult.success) {
+          // Schema rejected a valid expression — this is a failure
+          return false
+        }
+
+        // Compare amount from schema output to direct evaluate result
+        const schemaAmount = schemaResult.data.amount
+        if (Math.abs(evalResult.value) < 1e-10) {
+          return Math.abs(schemaAmount - evalResult.value) < 1e-6
+        }
+        return (
+          Math.abs((schemaAmount - evalResult.value) / evalResult.value) < 1e-9
+        )
+      }),
+      { numRuns: 200 },
+    )
+  })
+})

--- a/src/lib/math-expression.test.ts
+++ b/src/lib/math-expression.test.ts
@@ -1,0 +1,266 @@
+import type { EvalSuccess } from '@/lib/math-expression'
+import {
+  evaluate,
+  isExpression,
+  parse,
+  prettyPrint,
+} from '@/lib/math-expression'
+
+describe('math-expression evaluator', () => {
+  // --- Basic Arithmetic ---
+
+  describe('basic arithmetic', () => {
+    it('evaluates addition with decimals: "12+4.50" → 16.5', () => {
+      const result = evaluate('12+4.50')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(16.5)
+    })
+
+    it('evaluates division: "100/3" → 33.333...', () => {
+      const result = evaluate('100/3')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBeCloseTo(33.3333, 4)
+    })
+
+    it('evaluates grouped expression: "(50+25)*2" → 150', () => {
+      const result = evaluate('(50+25)*2')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(150)
+    })
+
+    it('evaluates subtraction: "10-3" → 7', () => {
+      const result = evaluate('10-3')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(7)
+    })
+
+    it('evaluates multiplication: "6*7" → 42', () => {
+      const result = evaluate('6*7')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(42)
+    })
+  })
+
+  // --- Unary Minus ---
+
+  describe('unary minus', () => {
+    it('evaluates "-5+3" → -2', () => {
+      const result = evaluate('-5+3')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(-2)
+    })
+
+    it('evaluates "(-5+3)" → -2', () => {
+      const result = evaluate('(-5+3)')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(-2)
+    })
+
+    it('evaluates double negation: "-(-5)" → 5', () => {
+      const result = evaluate('-(-5)')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(5)
+    })
+  })
+
+  // --- Operator Precedence ---
+
+  describe('operator precedence', () => {
+    it('respects multiplication before addition: "2+3*4" → 14', () => {
+      const result = evaluate('2+3*4')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(14)
+    })
+
+    it('respects parentheses override: "(2+3)*4" → 20', () => {
+      const result = evaluate('(2+3)*4')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(20)
+    })
+
+    it('respects division before subtraction: "10-6/2" → 7', () => {
+      const result = evaluate('10-6/2')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(7)
+    })
+  })
+
+  // --- Comma Decimals ---
+
+  describe('comma as decimal separator', () => {
+    it('evaluates "10,50+2,25" → 12.75', () => {
+      const result = evaluate('10,50+2,25')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(12.75)
+    })
+
+    it('evaluates "1,5*2" → 3', () => {
+      const result = evaluate('1,5*2')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(3)
+    })
+  })
+
+  // --- Whitespace Handling ---
+
+  describe('whitespace handling', () => {
+    it('evaluates " 5 + 3 " → 8', () => {
+      const result = evaluate(' 5 + 3 ')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(8)
+    })
+
+    it('evaluates expression with various spacing: "  10  *  2  " → 20', () => {
+      const result = evaluate('  10  *  2  ')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(20)
+    })
+  })
+
+  // --- Error Cases ---
+
+  describe('error cases', () => {
+    it('returns error for division by zero: "10/0"', () => {
+      const result = evaluate('10/0')
+      expect(result.ok).toBe(false)
+    })
+
+    it('returns error for unbalanced parentheses: "(5+3"', () => {
+      const result = evaluate('(5+3')
+      expect(result.ok).toBe(false)
+    })
+
+    it('returns error for trailing operator: "5+"', () => {
+      const result = evaluate('5+')
+      expect(result.ok).toBe(false)
+    })
+
+    it('returns error for empty parentheses: "()"', () => {
+      const result = evaluate('()')
+      expect(result.ok).toBe(false)
+    })
+
+    it('returns error for consecutive operators: "5++3"', () => {
+      const result = evaluate('5++3')
+      expect(result.ok).toBe(false)
+    })
+
+    it('returns error for invalid characters: "5+abc"', () => {
+      const result = evaluate('5+abc')
+      expect(result.ok).toBe(false)
+    })
+
+    it('returns error for empty input', () => {
+      const result = evaluate('')
+      expect(result.ok).toBe(false)
+    })
+
+    it('returns error for only whitespace', () => {
+      const result = evaluate('   ')
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  // --- Edge Cases ---
+
+  describe('edge cases', () => {
+    it('handles large numbers: "99999*99999"', () => {
+      const result = evaluate('99999*99999')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(9999800001)
+    })
+
+    it('handles deeply nested parentheses: "((((1+2))))"', () => {
+      const result = evaluate('((((1+2))))')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(3)
+    })
+
+    it('passes through a single number: "42"', () => {
+      const result = evaluate('42')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBe(42)
+    })
+
+    it('passes through a decimal number: "3.14"', () => {
+      const result = evaluate('3.14')
+      expect(result.ok).toBe(true)
+      expect((result as EvalSuccess).value).toBeCloseTo(3.14, 5)
+    })
+  })
+
+  // --- isExpression ---
+
+  describe('isExpression', () => {
+    it('returns true for expressions with operators', () => {
+      expect(isExpression('5+3')).toBe(true)
+      expect(isExpression('10-2')).toBe(true)
+      expect(isExpression('4*5')).toBe(true)
+      expect(isExpression('8/2')).toBe(true)
+    })
+
+    it('returns true for expressions with parentheses', () => {
+      expect(isExpression('(5+3)')).toBe(true)
+      expect(isExpression('(10)')).toBe(true)
+    })
+
+    it('returns false for plain numbers', () => {
+      expect(isExpression('42')).toBe(false)
+      expect(isExpression('3.14')).toBe(false)
+      expect(isExpression('100')).toBe(false)
+    })
+
+    it('returns false for negative numbers (leading unary minus only)', () => {
+      expect(isExpression('-5')).toBe(false)
+      expect(isExpression('-3.14')).toBe(false)
+    })
+
+    it('returns true for negative number in an expression', () => {
+      expect(isExpression('-5+3')).toBe(true)
+    })
+  })
+
+  // --- prettyPrint ---
+
+  describe('prettyPrint', () => {
+    it('prints simple addition', () => {
+      const result = parse('2+3')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(prettyPrint(result.ast)).toBe('2 + 3')
+      }
+    })
+
+    it('prints with correct precedence (no unnecessary parens)', () => {
+      const result = parse('2+3*4')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(prettyPrint(result.ast)).toBe('2 + 3 * 4')
+      }
+    })
+
+    it('prints parentheses when needed for precedence override', () => {
+      const result = parse('(2+3)*4')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(prettyPrint(result.ast)).toBe('(2 + 3) * 4')
+      }
+    })
+
+    it('prints unary minus', () => {
+      const result = parse('-5+3')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(prettyPrint(result.ast)).toBe('(-5) + 3')
+      }
+    })
+
+    it('prints nested expression', () => {
+      const result = parse('(1+2)*(3+4)')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(prettyPrint(result.ast)).toBe('(1 + 2) * (3 + 4)')
+      }
+    })
+  })
+})

--- a/src/lib/math-expression.ts
+++ b/src/lib/math-expression.ts
@@ -1,0 +1,371 @@
+// --- AST Types ---
+
+export type NumberNode = { type: 'number'; value: number }
+export type UnaryNode = { type: 'unary'; operator: '-'; operand: ExprNode }
+export type BinaryNode = {
+  type: 'binary'
+  operator: '+' | '-' | '*' | '/'
+  left: ExprNode
+  right: ExprNode
+}
+export type ExprNode = NumberNode | UnaryNode | BinaryNode
+
+// --- Result Types ---
+
+export type EvalSuccess = { ok: true; value: number }
+export type EvalError = { ok: false; error: string }
+export type EvalResult = EvalSuccess | EvalError
+
+// --- Token Types ---
+
+type TokenKind = 'number' | 'operator' | 'lparen' | 'rparen'
+type Token = { kind: TokenKind; value: string }
+
+// --- Allowed characters regex ---
+
+const ALLOWED_CHARS = /^[\d.,+\-*/() ]*$/
+
+// --- Tokenizer ---
+
+function tokenize(input: string): Token[] | null {
+  const tokens: Token[] = []
+  let i = 0
+
+  while (i < input.length) {
+    const ch = input[i]
+
+    // Skip whitespace
+    if (ch === ' ') {
+      i++
+      continue
+    }
+
+    // Number: digits, possibly with one decimal separator (. or ,)
+    if (ch >= '0' && ch <= '9') {
+      let num = ''
+      let hasDecimal = false
+      while (i < input.length) {
+        const c = input[i]
+        if (c >= '0' && c <= '9') {
+          num += c
+          i++
+        } else if ((c === '.' || c === ',') && !hasDecimal) {
+          // Look ahead to ensure there's at least one digit after the separator
+          if (
+            i + 1 < input.length &&
+            input[i + 1] >= '0' &&
+            input[i + 1] <= '9'
+          ) {
+            hasDecimal = true
+            num += '.'
+            i++
+          } else {
+            break
+          }
+        } else {
+          break
+        }
+      }
+      tokens.push({ kind: 'number', value: num })
+      continue
+    }
+
+    // Decimal separator at start (e.g., ".5" or ",5")
+    if (
+      (ch === '.' || ch === ',') &&
+      i + 1 < input.length &&
+      input[i + 1] >= '0' &&
+      input[i + 1] <= '9'
+    ) {
+      let num = '0.'
+      i++ // skip the separator
+      while (i < input.length && input[i] >= '0' && input[i] <= '9') {
+        num += input[i]
+        i++
+      }
+      tokens.push({ kind: 'number', value: num })
+      continue
+    }
+
+    // Operators
+    if (ch === '+' || ch === '-' || ch === '*' || ch === '/') {
+      tokens.push({ kind: 'operator', value: ch })
+      i++
+      continue
+    }
+
+    // Parentheses
+    if (ch === '(') {
+      tokens.push({ kind: 'lparen', value: '(' })
+      i++
+      continue
+    }
+    if (ch === ')') {
+      tokens.push({ kind: 'rparen', value: ')' })
+      i++
+      continue
+    }
+
+    // Invalid character
+    return null
+  }
+
+  return tokens
+}
+
+// --- Recursive-Descent Parser ---
+
+type ParseSuccess = { ok: true; ast: ExprNode }
+type ParseError = { ok: false; error: string }
+type ParseResult = ParseSuccess | ParseError
+
+/**
+ * Parse an expression string into an AST.
+ * Returns the AST or an error.
+ */
+export function parse(input: string): ParseResult {
+  // Validate allowed characters
+  if (!ALLOWED_CHARS.test(input)) {
+    return { ok: false, error: 'Invalid characters in expression' }
+  }
+
+  const trimmed = input.trim()
+  if (trimmed.length === 0) {
+    return { ok: false, error: 'Empty expression' }
+  }
+
+  const tokenized = tokenize(trimmed)
+  if (tokenized === null) {
+    return { ok: false, error: 'Invalid characters in expression' }
+  }
+  if (tokenized.length === 0) {
+    return { ok: false, error: 'Empty expression' }
+  }
+
+  const tokens: Token[] = tokenized
+  let pos = 0
+
+  function peek(): Token | undefined {
+    return tokens[pos]
+  }
+
+  function advance(): Token {
+    return tokens[pos++]
+  }
+
+  // Expression = Term (('+' | '-') Term)*
+  function parseExpression(): ExprNode | null {
+    let left = parseTerm()
+    if (left === null) return null
+
+    while (
+      peek() &&
+      peek()!.kind === 'operator' &&
+      (peek()!.value === '+' || peek()!.value === '-')
+    ) {
+      const op = advance().value as '+' | '-'
+      const right = parseTerm()
+      if (right === null) return null
+      left = { type: 'binary', operator: op, left, right }
+    }
+
+    return left
+  }
+
+  // Term = Factor (('*' | '/') Factor)*
+  function parseTerm(): ExprNode | null {
+    let left = parseFactor()
+    if (left === null) return null
+
+    while (
+      peek() &&
+      peek()!.kind === 'operator' &&
+      (peek()!.value === '*' || peek()!.value === '/')
+    ) {
+      const op = advance().value as '*' | '/'
+      const right = parseFactor()
+      if (right === null) return null
+      left = { type: 'binary', operator: op, left, right }
+    }
+
+    return left
+  }
+
+  // Factor = '-' Factor | Atom
+  function parseFactor(): ExprNode | null {
+    if (peek() && peek()!.kind === 'operator' && peek()!.value === '-') {
+      advance() // consume '-'
+      const operand = parseFactor()
+      if (operand === null) return null
+      return { type: 'unary', operator: '-', operand }
+    }
+    return parseAtom()
+  }
+
+  // Atom = '(' Expression ')' | Number
+  function parseAtom(): ExprNode | null {
+    const token = peek()
+    if (!token) return null
+
+    if (token.kind === 'lparen') {
+      advance() // consume '('
+      const expr = parseExpression()
+      if (expr === null) return null
+      const closing = peek()
+      if (!closing || closing.kind !== 'rparen') {
+        return null // unbalanced parenthesis
+      }
+      advance() // consume ')'
+      return expr
+    }
+
+    if (token.kind === 'number') {
+      advance()
+      const value = parseFloat(token.value)
+      return { type: 'number', value }
+    }
+
+    return null
+  }
+
+  const ast = parseExpression()
+  if (ast === null) {
+    return { ok: false, error: 'Syntax error in expression' }
+  }
+
+  // Ensure all tokens were consumed
+  if (pos < tokens.length) {
+    return { ok: false, error: 'Unexpected token after expression' }
+  }
+
+  return { ok: true, ast }
+}
+
+// --- Evaluator ---
+
+function evalNode(node: ExprNode): number {
+  switch (node.type) {
+    case 'number':
+      return node.value
+    case 'unary':
+      return -evalNode(node.operand)
+    case 'binary': {
+      const left = evalNode(node.left)
+      const right = evalNode(node.right)
+      switch (node.operator) {
+        case '+':
+          return left + right
+        case '-':
+          return left - right
+        case '*':
+          return left * right
+        case '/':
+          return left / right
+      }
+    }
+  }
+}
+
+/** Evaluate an arithmetic expression string to a numeric result. */
+export function evaluate(input: string): EvalResult {
+  const result = parse(input)
+  if (!result.ok) {
+    return { ok: false, error: result.error }
+  }
+
+  const value = evalNode(result.ast)
+
+  if (!Number.isFinite(value)) {
+    return { ok: false, error: 'Result is not finite' }
+  }
+
+  return { ok: true, value }
+}
+
+// --- Pretty Printer ---
+
+function precedence(op: '+' | '-' | '*' | '/'): number {
+  switch (op) {
+    case '+':
+    case '-':
+      return 1
+    case '*':
+    case '/':
+      return 2
+  }
+}
+
+function prettyPrintNode(
+  node: ExprNode,
+  parentOp?: '+' | '-' | '*' | '/',
+  isRight?: boolean,
+): string {
+  switch (node.type) {
+    case 'number':
+      // Format number: use integer when possible, otherwise trim trailing zeros
+      if (Number.isInteger(node.value)) {
+        return node.value.toString()
+      }
+      return node.value.toString()
+
+    case 'unary': {
+      const operandStr = prettyPrintNode(node.operand)
+      // If operand is a binary expression, wrap it in parens to preserve semantics
+      if (node.operand.type === 'binary') {
+        return `(-(${operandStr}))`
+      }
+      return `(-${operandStr})`
+    }
+
+    case 'binary': {
+      const left = prettyPrintNode(node.left, node.operator, false)
+      const right = prettyPrintNode(node.right, node.operator, true)
+      const expr = `${left} ${node.operator} ${right}`
+
+      if (parentOp === undefined) {
+        return expr
+      }
+
+      const parentPrec = precedence(parentOp)
+      const currentPrec = precedence(node.operator)
+
+      // Need parens if current precedence is lower than parent
+      if (currentPrec < parentPrec) {
+        return `(${expr})`
+      }
+
+      // For right-associativity: a - (b - c) and a / (b / c) need parens
+      if (
+        isRight &&
+        currentPrec === parentPrec &&
+        (parentOp === '-' || parentOp === '/')
+      ) {
+        return `(${expr})`
+      }
+
+      return expr
+    }
+  }
+}
+
+/**
+ * Pretty-print an AST back into a canonical expression string.
+ * Uses minimal parentheses based on operator precedence.
+ */
+export function prettyPrint(node: ExprNode): string {
+  return prettyPrintNode(node)
+}
+
+// --- isExpression ---
+
+/**
+ * Check if a string contains any arithmetic operators,
+ * indicating it's an expression rather than a plain number.
+ * Excludes a leading unary minus from triggering expression detection.
+ */
+export function isExpression(input: string): boolean {
+  // Strip leading whitespace and optional leading minus
+  const stripped = input.replace(/^\s*-?\s*/, '')
+  // Check for operator characters or parentheses in the remaining string
+  return /[+\-*/()]/.test(stripped)
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,4 +1,5 @@
 import { isPaymentCategory } from '@/lib/categories'
+import { evaluate, isExpression } from '@/lib/math-expression'
 import { RecurrenceRule, SplitMode } from '@prisma/client'
 import * as z from 'zod'
 
@@ -32,6 +33,33 @@ export function toAmountMinorUnitsForValidation(
   return Math.round(amount * factor)
 }
 
+/** Evaluate expression strings or parse plain numbers for amount fields. */
+function expressionToNumber(value: string, ctx: z.RefinementCtx): number {
+  // Fast path: plain number (no operators)
+  if (!isExpression(value)) {
+    const num = Number(value)
+    if (Number.isNaN(num)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'invalidNumber',
+      })
+      return 0
+    }
+    return num
+  }
+
+  // Expression path
+  const result = evaluate(value)
+  if (!result.ok) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'invalidExpression',
+    })
+    return 0
+  }
+  return result.value
+}
+
 export const groupFormSchema = z.object({
   name: z.string().min(2, 'min2').max(50, 'max50'),
   information: z.string().optional(),
@@ -61,21 +89,9 @@ export const expenseFormSchema = z
     title: z.string().default(''),
     category: z.coerce.number().default(0),
     amount: z
-      .union(
-        [
-          z.number(),
-          z.string().transform((value, ctx) => {
-            const valueAsNumber = Number(value)
-            if (Number.isNaN(valueAsNumber))
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: 'invalidNumber',
-              })
-            return valueAsNumber
-          }),
-        ],
-        { required_error: 'amountRequired' },
-      )
+      .union([z.number(), z.string().transform(expressionToNumber)], {
+        required_error: 'amountRequired',
+      })
       .refine((amount) => amount != 0, 'amountNotZero')
       .refine((amount) => amount <= 10_000_000_00, 'amountTenMillion'),
     originalAmount: z
@@ -250,21 +266,9 @@ export const expenseFormSchema = z
 export type ExpenseFormValues = z.infer<typeof expenseFormSchema>
 
 const paymentAmountSchema = z
-  .union(
-    [
-      z.number(),
-      z.string().transform((value, ctx) => {
-        const valueAsNumber = Number(value)
-        if (Number.isNaN(valueAsNumber))
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'invalidNumber',
-          })
-        return valueAsNumber
-      }),
-    ],
-    { required_error: 'amountRequired' },
-  )
+  .union([z.number(), z.string().transform(expressionToNumber)], {
+    required_error: 'amountRequired',
+  })
   .refine((amount) => amount > 0, 'amountNotZero')
   .refine((amount) => amount <= 10_000_000_00, 'amountTenMillion')
 


### PR DESCRIPTION
## Summary
- Add a pure recursive-descent math expression evaluator (`src/lib/math-expression.ts`) with unit and property tests
- Evaluate expressions on blur in `CurrencyAmountInput` and on submit via Zod amount transforms (expense + payment)
- i18n for `invalidExpression` and placeholder hint; mark the feature (and BYO OpenAI) done in the Kiro backlog/specs

## Test plan
- [ ] Create/edit an expense: type `12+4.50`, blur → field shows `16.5` (locale-formatted)
- [ ] Type `100/3`, blur → rounded to currency decimal digits
- [ ] Type `(50+25)*2`, submit without blurring → saves `150`
- [ ] Invalid expression (`10+`, `10/0`) → validation error blocks submit
- [ ] Payment form amount field behaves the same
- [ ] Plain numbers still work (no regression)
- [ ] Mobile: operator keys available (`inputMode=text`); placeholder shows expression hint
- [ ] `pnpm test` (math-expression + currency-amount-input) and `pnpm check-types` pass