### PR TITLE
feat: multi-payer expenses with Spliit-style Paid by UI

### DIFF
--- a/.kiro/FEATURE_BACKLOG.md
+++ b/.kiro/FEATURE_BACKLOG.md
@@ -44,9 +44,11 @@ feature notes the upstream issue for demand signal. Import the _ideas_, not the 
 ## Suggested order
 
 1. `multi-payer-expenses`
-2. `itemized-expenses`
-3. `account-overview-homepage`
-4. `profile-avatars`
+2. `paid-by-split-modes`
+3. `non-member-expense-decomposition`
+4. `itemized-expenses`
+5. `account-overview-homepage`
+6. `profile-avatars`
 
 ---
 
@@ -93,7 +95,43 @@ userId, amount|shares}`; migrate existing single-payer rows), balance math in
   - THE balance calculation SHALL credit each payer by their contributed amount.
   - WHEN migrating existing data, THE migration SHALL convert every current `paidById` into a single-payer row with the full amount (no balance change).
 
-## 2. `itemized-expenses` — Split by line items (with tax & tip)
+## 2. `paid-by-split-modes` — Spliit-style Paid by Choice Cards
+
+- **Size:** Medium. **Depends on:** `multi-payer-expenses` (`ExpensePaidBy` + `paidBy` array form field).
+- **Inspiration:** Spliit Cloud create-expense Paid by (Single vs Multiple: Evenly / Shares / % / Amount).
+- **Summary:** Redesign the Paid by section with shadcn Choice Cards. Single payer stays
+  one select; Multiple payers offers evenly / by shares / by percentage / by amount.
+  Modes are UI-only — the form still submits absolute `paidBy[]` amounts (no new DB column).
+- **Touch points:** `src/components/payer-selector.tsx`, `src/components/ui/field.tsx` +
+  `radio-group`, digit-aware helper in `src/lib/`, `expense-form` / floating create
+  `singlePayerOnly`, `messages/*.json`.
+- **Requirement seeds:**
+  - WHEN opening Paid by on a group expense, THE UI SHALL offer Single vs Multiple payers Choice Cards.
+  - WHEN Multiple + Evenly is selected, THE UI SHALL distribute the total with digit-aware minor-unit math.
+  - THE form SHALL always persist absolute payer amounts; Payer_Mode SHALL NOT be stored in the database.
+  - WHEN friends are selected in floating create, THE UI SHALL force Single payer only.
+
+## 3. `non-member-expense-decomposition` — Splitwise-style non-member shares
+
+- **Size:** Large. **Upstream:** Splitwise behaviour (confirmed via API).
+- **Depends on:** ideally after `multi-payer-expenses` (same create/update paths).
+- **Summary:** When creating a group expense that includes participants who are **not**
+  members of that group, atomically decompose into two records: (1) a group expense
+  covering only members' shares; (2) a direct expense (`groupId = null`) covering
+  non-members' shares. Both paid by the original payer, proportional to the original
+  split. UI explains the decomposition; original total stays visible for audit.
+- **Example:** Rafael creates 100€ in "Casa" (members: Rafael, Ana) including Daniel
+  (non-member), equal split → Casa gets 66.67€ (Rafael/Ana); direct 33.33€ Rafael↔Daniel.
+- **Touch points:** expense create/update tRPC + `src/lib/api.ts`, expense form
+  participant picker (allow non-members), balance/direct-expense modules, activity log,
+  i18n explanation copy, possibly link/audit fields between the two records.
+- **Requirement seeds:**
+  - WHEN an expense includes non-member participants, THE system SHALL create a group expense for members' shares and a direct expense for non-members' shares in one transaction.
+  - THE UI SHALL explain the decomposition before/after submit (e.g. "Daniel isn't in Casa — their share will be added as a direct expense").
+  - THE original total SHALL remain discoverable in both contexts for audit.
+  - THE payer and proportional split SHALL be preserved across both atomic records.
+
+## 4. `itemized-expenses` — Split by line items (with tax & tip)
 
 - **Size:** Large. **Upstream:** spliit #395.
 - **Summary:** Optionally break an expense into line items, assign each item to
@@ -107,7 +145,7 @@ userId, amount|shares}`; migrate existing single-payer rows), balance math in
   - THE system SHALL distribute tax and tip proportionally to each participant's item subtotal.
   - THE sum of per-person shares SHALL exactly equal the expense total (no lost cents).
 
-## 3. `account-overview-homepage` — Cross-group balance roll-up
+## 5. `account-overview-homepage` — Cross-group balance roll-up
 
 - **Size:** Medium. **Upstream:** spliit #509.
 - **Summary:** A logged-in landing page summarising the user's net position across all
@@ -120,7 +158,7 @@ userId, amount|shares}`; migrate existing single-payer rows), balance math in
   - THE overview SHALL list top balances with links to each group/friend.
   - THE aggregation SHALL run server-side via a single tRPC procedure.
 
-## 4. `profile-avatars` — Account profile photos
+## 6. `profile-avatars` — Account profile photos
 
 - **Size:** Medium.
 - **Summary:** Let users upload an avatar shown across account, group member lists, and

--- a/.kiro/specs/multi-payer-expenses/.config.kiro
+++ b/.kiro/specs/multi-payer-expenses/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "a3e7f1c2-84d9-4b6e-9f3a-2c1d8e5b7a04", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/multi-payer-expenses/design.md
+++ b/.kiro/specs/multi-payer-expenses/design.md
@@ -1,0 +1,453 @@
+# Design Document: Multi-Payer Expenses
+
+## Overview
+
+This design introduces support for expenses funded by multiple payers. Currently, every expense has a single `paidById` foreign key pointing to one user. This feature replaces that with a join table (`ExpensePaidBy`) that records one or more payers per expense, each with their contributed amount in minor currency units.
+
+The change touches the full vertical: database schema, balance computation, expense form UI, tRPC procedures, activity log diffing, import/export, and data migration. The design prioritizes backward compatibility — a single-payer expense is simply a multi-payer expense with one entry.
+
+### Key Design Decisions
+
+1. **New join table over array column** — A normalized `ExpensePaidBy` table (composite PK `expenseId + userId`) mirrors the existing `ExpensePaidFor` pattern, enabling referential integrity and efficient queries.
+2. **Retain `paidById` during transition** — The column is kept (deprecated) until all downstream consumers are migrated, enabling zero-downtime rollback.
+3. **Sum invariant enforced at API layer** — The sum of `ExpensePaidBy.amount` values must equal `Expense.amount`. This is validated in the tRPC procedure (not a DB constraint) to allow atomic creation.
+4. **Schema is always-array** — `expenseFormSchema.paidBy` is `Array<{participant, amount}>` (no union string|array). Reimbursements send a single-element array. This simplifies both client and server code.
+5. **Balance computation is additive** — Each payer's credit is summed independently; the `paidFor` (debit) side is unchanged.
+6. **Group expenses only (MVP)** — Multi-payer is only available for group expenses. Direct (friend) expenses remain single-payer in the MVP.
+7. **Payer amounts in group currency** — `ExpensePaidBy.amount` is always in group currency (minor units). When combined with currency conversion, conversion happens first (producing the group-currency total), then that total is distributed among payers.
+8. **Relation name: `payers`** — The Prisma relation on Expense is named `payers` (not `paidByMulti`) for readability. The table remains `ExpensePaidBy`.
+9. **"Split evenly" button** — When the expense total changes and payer amounts no longer match, a "Split evenly" button redistributes equally rather than auto-redistributing silently.
+
+---
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph "Client (React 19)"
+        A[ExpenseForm] --> B[PayerSelector component]
+        B --> C[usePayerAmounts hook]
+    end
+
+    subgraph "API Layer (tRPC)"
+        D[create.procedure] --> E[createExpense]
+        F[update.procedure] --> G[updateExpense]
+        E --> H[Prisma - Expense + ExpensePaidBy]
+        G --> H
+    end
+
+    subgraph "Core Logic"
+        I[balances.ts - getBalances]
+        J[activity-diff.ts - computeExpenseChanges]
+        K[splitwise-import.ts]
+        L[knots-import.ts]
+    end
+
+    subgraph "Export"
+        M[CSV route handler]
+        N[JSON route handler]
+    end
+
+    A -->|tRPC mutation| D
+    A -->|tRPC mutation| F
+    I -->|reads ExpensePaidBy| H
+    J -->|compares paidBy arrays| H
+    M -->|queries ExpensePaidBy| H
+    N -->|queries ExpensePaidBy| H
+```
+
+### Data Flow for Balance Computation
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant tRPC
+    participant getBalances
+    participant Prisma
+
+    Client->>tRPC: groups.balances.list(groupId)
+    tRPC->>Prisma: getGroupExpenses(groupId)
+    Prisma-->>tRPC: expenses[] with paidBy[] and paidFor[]
+    tRPC->>getBalances: compute(expenses)
+    Note over getBalances: For each expense:<br/>credit each payer by their amount<br/>debit each beneficiary by their share
+    getBalances-->>tRPC: Balances record
+    tRPC-->>Client: balances + reimbursements
+```
+
+---
+
+## Components and Interfaces
+
+### 1. PayerSelector Component
+
+A new React component replacing the single "Paid by" `<Select>` dropdown.
+
+```typescript
+// src/components/payer-selector.tsx
+
+interface PayerEntry {
+  participantId: string
+  amount: number | string // supports math expressions
+}
+
+interface PayerSelectorProps {
+  participants: Array<{ id: string; name: string }>
+  value: PayerEntry[]
+  onChange: (payers: PayerEntry[]) => void
+  expenseTotal: number
+  currency: Currency
+  locale: Locale
+  disabled?: boolean
+  isReimbursement?: boolean
+}
+```
+
+**Behavior:**
+
+- Renders one row per payer with a participant dropdown + amount input.
+- "Add payer" button appends a row (disabled when all participants used or `isReimbursement`).
+- Remove button on each row (disabled when only one payer remains).
+- Running total displayed with mismatch indicator (red when ≠ expense total).
+- Single-payer mode auto-fills amount to match expense total.
+- Supports arithmetic expressions in amount inputs via existing `CurrencyAmountInput`.
+
+### 2. Updated Form Schema
+
+```typescript
+// Addition to src/lib/schemas.ts
+
+const paidByEntrySchema = z.object({
+  participant: z.string().min(1),
+  amount: z
+    .union([z.number(), z.string().transform(expressionToNumber)])
+    .refine((a) => a > 0, 'paidByAmountPositive'),
+})
+
+// expenseFormSchema changes:
+// paidBy: z.string() → paidBy: z.array(paidByEntrySchema).min(1)
+// Always an array — no union with string. Reimbursements send [{participant, amount}].
+```
+
+### 3. Updated tRPC Procedures
+
+**create.procedure.ts** and **update.procedure.ts** changes:
+
+- Accept `paidBy` as `Array<{participant, amount}>`.
+- Validate: all participant IDs are group members.
+- Validate: sum of amounts equals expense total.
+- Create/update `ExpensePaidBy` rows in the same transaction.
+- Continue writing the deprecated `paidById` column (set to first payer's ID).
+
+### 4. Balance Calculator Interface
+
+```typescript
+// Updated getBalances signature (input type change)
+// expenses[].paidBy changes from { id: string; name: string }
+// to Array<{ user: { id: string; name: string }; amount: number }>
+```
+
+### 5. Activity Diff Interface
+
+```typescript
+// New field tracked in computeExpenseChanges:
+// field: 'paidBy'
+// oldValue: JSON.stringify([{userId, amount}, ...])
+// newValue: JSON.stringify([{userId, amount}, ...])
+```
+
+---
+
+## Data Models
+
+### New Model: ExpensePaidBy
+
+```prisma
+model ExpensePaidBy {
+  expense   Expense @relation("ExpensesPaidByMulti", fields: [expenseId], references: [id], onDelete: Cascade)
+  user      User    @relation("UserExpensesPaidBy", fields: [userId], references: [id], onDelete: Cascade)
+  expenseId String
+  userId    String
+  amount    Int     // minor currency units
+
+  @@id([expenseId, userId])
+}
+```
+
+### Schema Changes to Expense Model
+
+```prisma
+model Expense {
+  // ... existing fields ...
+
+  // DEPRECATED — kept for rollback; set to first payer's ID
+  paidBy           User              @relation("ExpensesPaidBy", fields: [paidById], references: [id])
+  paidById         String
+
+  // NEW — one or more payers with amounts
+  payers           ExpensePaidBy[]   @relation("ExpensesPaidByMulti")
+
+  // ... rest unchanged ...
+}
+```
+
+### Schema Changes to User Model
+
+```prisma
+model User {
+  // ... existing fields ...
+  expensesPaidBy    Expense[]         @relation("ExpensesPaidBy") // legacy
+  paidByExpenses    ExpensePaidBy[]   @relation("UserExpensesPaidBy") // new
+  // ...
+}
+```
+
+### Migration Strategy
+
+1. **Step 1: Add `ExpensePaidBy` table** — Standard Prisma migration adding the new table with composite PK.
+2. **Step 2: Data migration script** — For each existing expense, insert one `ExpensePaidBy` row with `userId = paidById` and `amount = expense.amount`. This is idempotent (upsert on composite key).
+3. **Step 3: Application code deploys** — Code reads from `ExpensePaidBy`; writes to both `ExpensePaidBy` and `paidById`.
+4. **Step 4 (future): Drop `paidById`** — After confirming stability, a follow-up migration removes the deprecated column.
+
+```sql
+-- Idempotent data migration (Step 2)
+INSERT INTO "ExpensePaidBy" ("expenseId", "userId", "amount")
+SELECT e."id", e."paidById", e."amount"
+FROM "Expense" e
+WHERE NOT EXISTS (
+  SELECT 1 FROM "ExpensePaidBy" epb WHERE epb."expenseId" = e."id"
+)
+ON CONFLICT ("expenseId", "userId") DO NOTHING;
+```
+
+### Query Changes
+
+The `getGroupExpenses` select and `getExpense` include must add:
+
+```typescript
+payers: {
+  select: { userId: true, amount: true, user: { select: { id: true, name: true } } }
+}
+```
+
+---
+
+## Correctness Properties
+
+_A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: Payer Amount Sum Invariant
+
+_For any_ valid expense with one or more payers, the sum of all `ExpensePaidBy.amount` values SHALL equal the `Expense.amount` (the expense total). Any expense submission where the sum diverges from the total SHALL be rejected with a validation error indicating the exact difference.
+
+**Validates: Requirements 1.4, 3.3, 2.7, 11.2, 11.3**
+
+### Property 2: Per-Payer Credit Accumulation
+
+_For any_ expense with N payers, the balance calculator SHALL credit each payer's `paid` total by exactly their `ExpensePaidBy.amount`. The sum of all payer credits across the group SHALL equal the sum of expense totals.
+
+**Validates: Requirements 3.1, 1.3**
+
+### Property 3: PaidFor Independence from Payer Distribution
+
+_For any_ expense, the `paidFor` (debit) amounts computed for each beneficiary SHALL be identical regardless of how the expense total is distributed among payers. Only the `paidBy` credit side is affected by the payer distribution.
+
+**Validates: Requirements 3.2**
+
+### Property 4: Single-Payer Backward Compatibility
+
+_For any_ expense with exactly one payer whose amount equals the expense total, the balance calculator SHALL produce identical `paid`, `paidFor`, and `total` values to the current single-payer computation.
+
+**Validates: Requirements 3.4**
+
+### Property 5: Activity Diff Payer Change Detection
+
+_For any_ two payer states (old and new), the activity diff SHALL record a `paidBy` field change if and only if the sets of (userId, amount) pairs differ. The serialized values SHALL be parseable JSON arrays of `{userId, amount}` objects that round-trip back to the original payer states.
+
+**Validates: Requirements 5.1, 5.2, 5.4**
+
+### Property 6: Migration Correctness and Idempotence
+
+_For any_ set of existing expenses, the data migration SHALL create exactly one `ExpensePaidBy` row per expense (with `userId = paidById` and `amount = expense.amount`), and running the migration N times SHALL produce the same database state as running it once (no duplicate rows).
+
+**Validates: Requirements 6.1, 6.3**
+
+### Property 7: Migration Balance Preservation
+
+_For any_ group, the net balance (paid − paidFor) for every participant SHALL be identical before and after the data migration.
+
+**Validates: Requirements 6.4**
+
+### Property 8: Splitwise Multi-Payer Import
+
+_For any_ Splitwise CSV row with K positive user-column values (K ≥ 1), the importer SHALL produce exactly K payer entries whose amounts equal the corresponding positive column values (converted to minor units) and whose sum equals the row's cost exactly (with rounding remainder assigned to the last payer).
+
+**Validates: Requirements 7.1, 7.3, 7.4**
+
+### Property 9: Knots JSON Multi-Payer Import
+
+_For any_ Knots JSON export expense containing a `paidBy` array with M entries, the importer SHALL create exactly M `ExpensePaidBy` rows with matching userIds and amounts.
+
+**Validates: Requirements 8.1**
+
+### Property 10: Payer UserId Validation
+
+_For any_ expense creation or update request, if any payer's `userId` is not a member of the target group, the system SHALL reject the request with a BAD_REQUEST error. This applies uniformly to form submission, Knots import, and Splitwise import.
+
+**Validates: Requirements 1.6, 8.3, 11.4, 11.5**
+
+### Property 11: CSV Export Per-Participant Values
+
+_For any_ expense with multiple payers, the CSV export SHALL output per-participant column values where each payer's column equals their credit (positive) minus their beneficiary debit (if any), and each non-payer beneficiary's column equals their negative debit. The sum of all participant columns SHALL equal zero.
+
+**Validates: Requirements 9.1, 9.2**
+
+### Property 12: CSV Export Single-Payer Backward Compatibility
+
+_For any_ single-payer expense, the CSV export produced by the multi-payer code SHALL be byte-identical to the output of the current single-payer export logic.
+
+**Validates: Requirements 9.3**
+
+### Property 13: JSON Export PaidBy Array Presence
+
+_For any_ exported expense (regardless of payer count), the JSON export SHALL include a `paidBy` array containing objects with `userId` and `amount` fields, with one entry per payer.
+
+**Validates: Requirements 10.1, 10.2**
+
+### Property 14: JSON Export Legacy PaidById Field
+
+_For any_ exported expense, the `paidById` field in the JSON export SHALL equal the `userId` of the first entry in the `paidBy` array.
+
+**Validates: Requirements 10.3**
+
+### Property 15: Per-Payer Amount Positivity Validation
+
+_For any_ per-payer amount that is zero or negative, the system SHALL reject the expense submission with an inline validation error on that specific payer's input.
+
+**Validates: Requirements 11.1**
+
+### Property 16: Recurring Expense PaidBy Propagation
+
+_For any_ recurring expense with N payers, each materialized instance SHALL contain exactly N `ExpensePaidBy` rows with the same userIds and amounts as the source expense at the time of materialization.
+
+**Validates: Requirements 12.1, 12.2**
+
+### Property 17: No Duplicate Payer Participants
+
+_For any_ expense, no two `ExpensePaidBy` rows SHALL reference the same `userId`. The form and API SHALL reject submissions containing duplicate payer participants.
+
+**Validates: Requirements 2.5**
+
+---
+
+## Error Handling
+
+### Client-Side Validation Errors
+
+| Condition                            | Error Display                                  | Behavior           |
+| ------------------------------------ | ---------------------------------------------- | ------------------ |
+| Payer amount ≤ 0                     | Inline error on that payer's amount input      | Prevent submission |
+| Sum of payer amounts > expense total | Banner: "Overpayment by {diff}"                | Prevent submission |
+| Sum of payer amounts < expense total | Banner: "Underpayment by {diff}"               | Prevent submission |
+| Duplicate participant selected       | Participant excluded from dropdown             | Prevented by UI    |
+| Second payer added to reimbursement  | Toast: "Reimbursements support only one payer" | Button disabled    |
+
+### Server-Side Validation Errors
+
+| Condition                             | tRPC Error Code | Message                                        |
+| ------------------------------------- | --------------- | ---------------------------------------------- |
+| Payer userId not a group member       | `BAD_REQUEST`   | `"User {userId} is not a group member"`        |
+| Sum of payer amounts ≠ expense amount | `BAD_REQUEST`   | `"Payer amounts must sum to expense total"`    |
+| Empty paidBy array                    | `BAD_REQUEST`   | `"At least one payer is required"`             |
+| Reimbursement with >1 payer           | `BAD_REQUEST`   | `"Reimbursements support only a single payer"` |
+| Duplicate userId in paidBy            | `BAD_REQUEST`   | `"Duplicate payer: {userId}"`                  |
+
+### Import Error Handling
+
+| Condition                                        | Behavior                                     |
+| ------------------------------------------------ | -------------------------------------------- |
+| Splitwise CSV: rounding mismatch                 | Auto-adjust last payer's amount silently     |
+| Knots JSON: paidBy entry references unknown user | Reject entire expense with descriptive error |
+| Knots JSON: legacy format (no paidBy array)      | Fall back to single-payer creation           |
+| Migration: duplicate row attempt                 | `ON CONFLICT DO NOTHING` (idempotent)        |
+
+### Graceful Degradation
+
+- If `ExpensePaidBy` rows are somehow missing for an expense (data corruption), the balance calculator falls back to reading the deprecated `paidById` column and treats it as a single-payer expense with the full amount.
+- The JSON exporter includes a `paidById` legacy field so older Knots importers continue working without modification.
+
+---
+
+## Testing Strategy
+
+### Property-Based Testing (fast-check)
+
+This feature is highly suitable for PBT because:
+
+- Balance computation is a pure function with clear input/output behavior.
+- The sum invariant and independence properties are universal across all valid inputs.
+- The input space is large (varying numbers of payers, amounts, split modes, participant counts).
+
+**Library:** `fast-check` (already available or easily addable to the TypeScript/Jest ecosystem)
+**Minimum iterations:** 100 per property test
+**Tag format:** `Feature: multi-payer-expenses, Property {N}: {title}`
+
+Each correctness property above maps to one property-based test. The generators produce:
+
+- Random participant lists (2–10 members)
+- Random payer subsets (1–all participants) with random positive integer amounts summing to a random total
+- Random split modes with valid share distributions
+- Random expense dates, titles, categories
+
+### Unit Tests (Example-Based)
+
+- Form initialization defaults (Requirement 2.1)
+- Add/remove payer UI interactions (Requirements 2.2, 2.3)
+- Reimbursement payer restriction (Requirements 4.1, 4.2)
+- Activity diff creation change (Requirement 5.3)
+- Migration handles null groupId (Requirement 6.5)
+- Splitwise single-payer import (Requirement 7.2)
+- Knots legacy format import (Requirement 8.2)
+- JSON export single-payer has array (Requirement 10.2)
+- Recurring expense source edit isolation (Requirement 12.3)
+
+### Integration Tests
+
+- End-to-end create expense via tRPC with multi-payer data → verify DB state
+- End-to-end update expense changing payers → verify activity log and DB
+- CSV export → re-import round trip for multi-payer data
+- JSON export → Knots import round trip
+
+### Test File Locations
+
+- `src/lib/__tests__/balances-multi-payer.property.test.ts` — Properties 1–4
+- `src/lib/__tests__/activity-diff-multi-payer.property.test.ts` — Property 5
+- `src/lib/__tests__/migration-multi-payer.property.test.ts` — Properties 6, 7
+- `src/lib/__tests__/splitwise-import-multi-payer.property.test.ts` — Property 8
+- `src/lib/__tests__/knots-import-multi-payer.property.test.ts` — Properties 9, 10
+- `src/lib/__tests__/export-multi-payer.property.test.ts` — Properties 11–14
+- `src/lib/__tests__/validation-multi-payer.property.test.ts` — Properties 15, 17
+- `src/lib/__tests__/recurring-multi-payer.property.test.ts` — Property 16
+
+---
+
+## File Change Summary
+
+| File                                                     | Change Type | Description                                                                                         |
+| -------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------- |
+| `prisma/schema.prisma`                                   | Modify      | Add `ExpensePaidBy` model, add `payers` relation to `Expense`, add `paidByExpenses` to `User`       |
+| `prisma/migrations/XXXXXX_add_expense_paid_by/`          | Add         | Migration SQL for new table                                                                         |
+| `prisma/migrations/XXXXXX_backfill_expense_paid_by/`     | Add         | Idempotent data backfill script                                                                     |
+| `src/lib/schemas.ts`                                     | Modify      | Add `paidByEntrySchema`, update `expenseFormSchema` to use `z.array(paidByEntrySchema).min(1)`      |
+| `src/lib/balances.ts`                                    | Modify      | `getBalances` iterates `payers` array instead of single `paidBy`                                    |
+| `src/lib/activity-diff.ts`                               | Modify      | `computeExpenseChanges` tracks `paidBy` array field (old/new serialization)                         |
+| `src/lib/api.ts`                                         | Modify      | `createExpense` and `updateExpense` write `ExpensePaidBy` rows; `getGroupExpenses` selects `payers` |
+| `src/lib/splitwise-import.ts`                            | Modify      | `parseExpenseRow` detects multi-payer CSV rows, produces paidBy array                               |
+| `src/lib/knots-import.ts`                                | Modify      | Schema + parser accept `paidBy` array; legacy fallback to `paidById`                                |
+| `src/trpc/routers/groups/expenses/create.procedure.ts`   | Modify      | Validate paidBy array, pass to `createExpense`                                                      |
+| `src/trpc/routers/groups/expenses/update.procedure.ts`   | Modify      | Validate paidBy array, pass to `updateExpense`                                                      |
+| `src/app/groups/[groupId]/expenses/expense-form.tsx`     | Modify      | Replace single payer `<Select>` with `<PayerSelector>`                                              |
+| `src/components/payer-selector.tsx`                      | Add         | New multi-payer selector component                                                                  |
+| `src/app/groups/[groupId]/expenses/export/csv/route.ts`  | Modify      | Use `payers` for per-participant credit computation                                                 |
+| `src/app/groups/[groupId]/expenses/export/json/route.ts` | Modify      | Add `paidBy` array to export; retain legacy `paidById`                                              |
+| `messages/en.json` (+ all 19 locales)                    | Modify      | Add i18n keys for payer selector UI, validation errors                                              |
+| `src/lib/__tests__/*.property.test.ts`                   | Add         | Property-based tests for all correctness properties                                                 |

--- a/.kiro/specs/multi-payer-expenses/requirements.md
+++ b/.kiro/specs/multi-payer-expenses/requirements.md
@@ -1,0 +1,168 @@
+# Requirements Document
+
+## Introduction
+
+Support for expenses funded by multiple payers, each contributing a specific amount or share toward the expense total. Currently, every expense has a single `paidById` field pointing to one user. This feature introduces a join table (`ExpensePaidBy`) that records one or more payers per expense, each with their contributed amount. The balance computation credits each payer by their specific contribution rather than crediting the entire total to a single user. The expense form replaces the single "Paid by" dropdown with a multi-payer selector, and all downstream systems (activity log, import, export, data migration) are updated accordingly.
+
+**Scope decisions:**
+
+- Multi-payer is available only for **group expenses** in the MVP. Direct (friend) expenses remain single-payer.
+- `ExpensePaidBy.amount` is always in **group currency** (minor units). When combined with `server-authoritative-currency-conversion`, conversion happens first, then the converted total is distributed among payers.
+- The `paidBy` field in form schema and tRPC input is **always an array** (`[{participant, amount}]`). No union string|array — reimbursements simply send a single-element array.
+
+## Glossary
+
+- **Expense_Form**: The React component (`ExpenseForm`) where the user creates or edits an expense, including payer selection and split configuration.
+- **Payer_Selector**: The UI section within the Expense_Form that allows selecting one or more group participants as payers with per-payer amounts.
+- **ExpensePaidBy**: A new Prisma join table linking an expense to one or more paying users, each with an `amount` field (integer, minor currency units) representing their contribution.
+- **Balance_Calculator**: The module (`src/lib/balances.ts`) that computes per-participant paid/owed totals across all group expenses.
+- **Activity_Diff**: The module (`src/lib/activity-diff.ts`) that computes field-level changes between expense versions for the activity log.
+- **Splitwise_Importer**: The module (`src/lib/splitwise-import.ts`) that parses Splitwise CSV exports and converts them into expense form values.
+- **Knots_Importer**: The tRPC procedure that imports previously exported Knots JSON data into a group.
+- **CSV_Exporter**: The route handler that exports group expenses to CSV format.
+- **JSON_Exporter**: The route handler that exports group expenses to JSON format.
+- **Migration**: A Prisma migration that converts existing single-payer data into `ExpensePaidBy` rows without altering balances.
+- **Payer_Amount**: The integer amount (in group currency minor units) that a specific payer contributed toward an expense total. When currency conversion is involved, conversion happens before payer distribution — payer amounts are always in group currency.
+- **Expense_Total**: The `amount` field on the Expense model representing the total cost of the expense in group currency minor units.
+
+## Requirements
+
+### Requirement 1: Multi-Payer Data Model
+
+**User Story:** As a developer, I want a data model that supports multiple payers per expense with individual amounts, so that the system can accurately track who paid what.
+
+#### Acceptance Criteria
+
+1. THE ExpensePaidBy model SHALL store a composite key of `expenseId` and `userId`, plus an `amount` field (integer, minor currency units).
+2. THE Expense model SHALL maintain a `paidBy` relation to one or more ExpensePaidBy rows.
+3. WHEN an expense is created, THE system SHALL create one ExpensePaidBy row per payer with the corresponding Payer_Amount.
+4. THE sum of all ExpensePaidBy amounts for a given expense SHALL equal the Expense_Total.
+5. THE ExpensePaidBy model SHALL cascade-delete when the parent Expense is deleted.
+6. THE ExpensePaidBy model SHALL enforce that `userId` references a valid group participant.
+
+### Requirement 2: Expense Form Multi-Payer Selection
+
+**User Story:** As a user, I want to select one or more payers when creating or editing an expense, so that I can record shared payments accurately.
+
+#### Acceptance Criteria
+
+1. WHEN the user opens the Expense_Form, THE Payer_Selector SHALL default to a single payer (the current user or first participant) with the full Expense_Total.
+2. WHEN the user adds a payer, THE Payer_Selector SHALL display an additional row with a participant selector and an amount input.
+3. WHEN the user removes a payer, THE Payer_Selector SHALL remove that row and redistribute the remaining amount among the remaining payers.
+4. THE Payer_Selector SHALL allow selecting any group participant as a payer.
+5. THE Payer_Selector SHALL prevent selecting the same participant as a payer more than once.
+6. THE Payer_Selector SHALL display a running total of all per-payer amounts and indicate whether the total matches the Expense_Total.
+7. IF the sum of per-payer amounts does not equal the Expense_Total, THEN THE Expense_Form SHALL prevent submission and display a validation error.
+8. WHEN only one payer is selected, THE Payer_Selector SHALL auto-fill that payer's amount to match the Expense_Total.
+9. THE Payer_Selector SHALL support arithmetic expressions in per-payer amount inputs, consistent with the existing amount field behavior.
+10. WHEN the user changes the Expense_Total, THE Payer_Selector SHALL retain existing payer amounts and display the mismatch. A "Split evenly" button SHALL redistribute the total equally among current payers when clicked.
+11. THE Payer_Selector SHALL only be available for group expenses. Direct (friend) expenses SHALL continue using the existing single-payer selector.
+
+### Requirement 3: Balance Calculation with Multiple Payers
+
+**User Story:** As a user, I want balances to correctly reflect each payer's contribution, so that settlement suggestions are accurate when multiple people pay for an expense.
+
+#### Acceptance Criteria
+
+1. THE Balance_Calculator SHALL credit each payer's `paid` total by their respective Payer_Amount from the ExpensePaidBy record.
+2. THE Balance_Calculator SHALL compute `paidFor` (owed) amounts using the existing split-mode logic, independent of how many payers contributed.
+3. FOR ALL expenses, the sum of all payer credits SHALL equal the Expense_Total (invariant: total paid equals total owed across the group).
+4. WHEN an expense has a single payer, THE Balance_Calculator SHALL produce identical results to the current single-payer computation.
+5. THE Balance_Calculator SHALL handle the case where a participant is both a payer and a beneficiary of the same expense, netting their position correctly.
+6. THE Balance_Calculator SHALL use integer arithmetic (minor currency units) and distribute rounding remainders to the last participant, consistent with existing behavior.
+
+### Requirement 4: Reimbursement and Settlement Compatibility
+
+**User Story:** As a user, I want reimbursements (payments) to remain single-payer only, so that the settlement flow stays simple and unambiguous.
+
+#### Acceptance Criteria
+
+1. WHEN an expense is marked as a reimbursement (`isReimbursement = true`), THE Expense_Form SHALL restrict the Payer_Selector to exactly one payer.
+2. WHEN a user attempts to add a second payer to a reimbursement, THE Expense_Form SHALL display an error message indicating that reimbursements support only a single payer.
+3. THE Balance_Calculator SHALL process reimbursement expenses using only the single ExpensePaidBy row, consistent with existing settlement logic.
+
+### Requirement 5: Activity Log Diff for Payer Changes
+
+**User Story:** As a user, I want the activity log to show when the payers of an expense change, so that I can track who edited payment responsibilities.
+
+#### Acceptance Criteria
+
+1. WHEN the set of payers or their amounts change during an expense update, THE Activity_Diff SHALL record a `paidBy` field change.
+2. THE Activity_Diff SHALL serialize the old payer state as a structured value (list of userId:amount pairs) and the new payer state in the same format.
+3. WHEN a new expense is created, THE Activity_Diff SHALL record the initial payer set as a creation change (oldValue: null, newValue: payer list).
+4. WHEN a single-payer expense remains single-payer with the same user and amount, THE Activity_Diff SHALL not record a `paidBy` change.
+
+### Requirement 6: Data Migration from Single-Payer Model
+
+**User Story:** As a developer, I want to migrate existing single-payer expenses to the new multi-payer model without changing any balances, so that the transition is seamless for users.
+
+#### Acceptance Criteria
+
+1. WHEN the migration runs, THE Migration SHALL create one ExpensePaidBy row for each existing expense with `userId` set to the current `paidById` and `amount` set to the full Expense_Total.
+2. THE Migration SHALL preserve the existing `paidById` column (deprecated but not removed) during the transition period to allow rollback.
+3. THE Migration SHALL be idempotent — running it multiple times SHALL not create duplicate ExpensePaidBy rows.
+4. THE Migration SHALL not alter any balance computations — net positions for all users in all groups SHALL remain identical before and after migration.
+5. THE Migration SHALL handle expenses with null `groupId` (orphaned or direct-friend expenses) by still creating the corresponding ExpensePaidBy row.
+
+### Requirement 7: Splitwise CSV Import with Multi-Payer Support
+
+**User Story:** As a user, I want to import Splitwise CSV files that have expenses paid by multiple people, so that my historical data is accurately represented.
+
+#### Acceptance Criteria
+
+1. WHEN a Splitwise CSV row has multiple user columns with positive amounts, THE Splitwise_Importer SHALL create an ExpensePaidBy entry for each user with a positive amount.
+2. WHEN a Splitwise CSV row has exactly one user column with a positive amount, THE Splitwise_Importer SHALL create a single-payer ExpensePaidBy entry (backward-compatible behavior).
+3. THE Splitwise_Importer SHALL use each payer's positive column value directly as their Payer_Amount (in the expense's currency minor units). The importer SHALL validate this against a real Splitwise CSV before finalizing the logic.
+4. IF the sum of imported payer amounts does not equal the row's cost (due to Splitwise rounding), THEN THE Splitwise_Importer SHALL adjust the last payer's amount to reconcile the difference.
+
+### Requirement 8: Knots JSON Import with Multi-Payer Support
+
+**User Story:** As a user, I want to import Knots JSON exports that include multi-payer data, so that I can restore or transfer group data faithfully.
+
+#### Acceptance Criteria
+
+1. WHEN a Knots JSON export contains a `paidBy` array on an expense, THE Knots_Importer SHALL create one ExpensePaidBy row per entry.
+2. WHEN a Knots JSON export contains only the legacy `paidById` field (no `paidBy` array), THE Knots_Importer SHALL create a single ExpensePaidBy row with the full Expense_Total.
+3. IF a `paidBy` array entry references a userId not present in the group participants, THEN THE Knots_Importer SHALL reject the expense import with a descriptive error.
+
+### Requirement 9: CSV Export with Multi-Payer Data
+
+**User Story:** As a user, I want the CSV export to represent multi-payer information, so that exported data can be analyzed or re-imported accurately.
+
+#### Acceptance Criteria
+
+1. WHEN an expense has multiple payers, THE CSV_Exporter SHALL output a per-participant column value that reflects each payer's credit (positive amount) and each beneficiary's debit (negative amount).
+2. WHEN a participant is both a payer and a beneficiary of the same expense, THE CSV_Exporter SHALL output the net amount (payer credit minus beneficiary debit) for that participant.
+3. THE CSV_Exporter SHALL maintain backward compatibility — single-payer expenses SHALL produce identical CSV output to the current format.
+
+### Requirement 10: JSON Export with Multi-Payer Data
+
+**User Story:** As a user, I want the JSON export to include the full multi-payer breakdown, so that the export is a complete representation of expense data.
+
+#### Acceptance Criteria
+
+1. WHEN an expense has multiple payers, THE JSON_Exporter SHALL include a `paidBy` array containing objects with `userId` and `amount` fields.
+2. WHEN an expense has a single payer, THE JSON_Exporter SHALL still include the `paidBy` array (with one entry) for format consistency.
+3. THE JSON_Exporter SHALL retain the legacy `paidById` field set to the first payer's userId for backward compatibility with older Knots importers.
+
+### Requirement 11: Form Validation and Error Handling
+
+**User Story:** As a user, I want clear validation feedback when payer amounts are incorrect, so that I can fix errors before submitting.
+
+#### Acceptance Criteria
+
+1. IF any per-payer amount is zero or negative, THEN THE Expense_Form SHALL display an inline validation error on that payer's amount input.
+2. IF the sum of per-payer amounts exceeds the Expense_Total, THEN THE Expense_Form SHALL display an error indicating the overpayment amount.
+3. IF the sum of per-payer amounts is less than the Expense_Total, THEN THE Expense_Form SHALL display an error indicating the underpayment amount.
+4. WHEN the Expense_Form is submitted with valid payer data, THE tRPC create/update procedure SHALL verify that all payer userIds are group members.
+5. IF a payer userId is not a group member, THEN THE tRPC procedure SHALL return a BAD_REQUEST error with a descriptive message.
+
+### Requirement 12: Recurring Expense Multi-Payer Propagation
+
+**User Story:** As a user, I want recurring expenses to preserve multi-payer information when new instances are materialized, so that recurring shared payments are handled automatically.
+
+#### Acceptance Criteria
+
+1. WHEN a recurring expense instance is materialized, THE system SHALL copy all ExpensePaidBy rows from the source expense to the new instance.
+2. THE materialized instance SHALL have the same set of payers and per-payer amounts as the source expense.
+3. WHEN the source recurring expense is edited to change payers, THE system SHALL use the updated payers for future materializations only (existing materialized instances remain unchanged).

--- a/.kiro/specs/multi-payer-expenses/tasks.md
+++ b/.kiro/specs/multi-payer-expenses/tasks.md
@@ -1,0 +1,370 @@
+# Implementation Plan: Multi-Payer Expenses
+
+## Overview
+
+This plan implements support for expenses funded by multiple payers. The work is organized into six phases: database schema & migration, core logic (balances, activity diff), tRPC API layer, UI components, import/export systems, and testing. Each phase builds on the previous, ensuring no orphaned code. All amounts use integer minor currency units.
+
+## Tasks
+
+- [x] 1. Database schema and migration
+  - [x] 1.1 Add ExpensePaidBy model to Prisma schema
+    - Add `ExpensePaidBy` model to `prisma/schema.prisma` with composite key `[expenseId, userId]` and `amount Int`
+    - Add `payers ExpensePaidBy[]` relation on `Expense` model with `@relation("ExpensesPaidByMulti")`
+    - Add `paidByExpenses ExpensePaidBy[]` on `User` model with `@relation("UserExpensesPaidBy")`
+    - Configure `onDelete: Cascade` on both foreign key relations
+    - Keep existing `paidById` / `paidBy` relation intact (deprecated)
+    - _Requirements: 1.1, 1.2, 1.5, 1.6_
+
+  - [x] 1.2 Generate and apply Prisma migration
+    - Run `npx prisma migrate dev --name add_expense_paid_by` to generate migration SQL
+    - Verify the migration creates the `ExpensePaidBy` table with composite primary key
+    - _Requirements: 1.1_
+
+  - [x] 1.3 Create idempotent data backfill migration
+    - Create `prisma/migrations/XXXXXX_backfill_expense_paid_by/migration.sql` with idempotent INSERT
+    - SQL: `INSERT INTO "ExpensePaidBy" ("expenseId", "userId", "amount") SELECT e."id", e."paidById", e."amount" FROM "Expense" e WHERE NOT EXISTS (SELECT 1 FROM "ExpensePaidBy" epb WHERE epb."expenseId" = e."id") ON CONFLICT ("expenseId", "userId") DO NOTHING;`
+    - Handle expenses with null `groupId` (orphaned/direct-friend expenses)
+    - _Requirements: 6.1, 6.2, 6.3, 6.5_
+
+  - [x] 1.4 Update `getGroupExpenses` and `getExpense` queries to include `payers`
+    - Modify `src/lib/api.ts` — add `payers: { select: { userId: true, amount: true, user: { select: { id: true, name: true } } } }` to all expense includes
+    - _Requirements: 1.2, 3.1_
+
+- [x] 2. Core logic — balance computation
+  - [x] 2.1 Refactor `getBalances` to support multiple payers
+    - Modify `src/lib/balances.ts` — replace `expense.paidBy.id` single-payer credit with iteration over `expense.payers` array
+    - Credit each payer by their `amount` field instead of the full `expense.amount`
+    - Keep `paidFor` (debit) logic completely unchanged
+    - Add fallback: if `payers` is empty/undefined, fall back to `expense.paidBy.id` with full amount (graceful degradation)
+    - Ensure integer arithmetic and rounding remainder behavior is preserved
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6_
+
+  - [x] 2.2 Update `getDirectReimbursements` for multi-payer
+    - Modify `src/lib/balances.ts` — `getDirectReimbursements` currently calls `getBalances([expense])` per expense, ensure this still works with new multi-payer logic
+    - The pair-owes map should credit each payer individually
+    - _Requirements: 3.1, 3.5_
+
+  - [x] 2.3 Write unit tests for multi-payer balance computation
+    - Create/extend `src/lib/balances.test.ts` with test cases:
+      - Single payer (backward compatibility): same result as before
+      - Two payers splitting payment evenly
+      - Three payers with uneven amounts
+      - Payer who is also a beneficiary (net position)
+      - Rounding remainder with multiple payers
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6_
+
+  - [x] 2.4 Write property test: Payer Amount Sum Invariant (Property 1)
+    - **Property 1: Payer Amount Sum Invariant**
+    - Create `src/lib/__tests__/balances-multi-payer.property.test.ts`
+    - Generate random expenses with 1–N payers whose amounts sum to expense total
+    - Assert: sum of all payer credits in balances equals sum of expense totals
+    - **Validates: Requirements 1.4, 3.3, 2.7, 11.2, 11.3**
+
+  - [x] 2.5 Write property test: Per-Payer Credit Accumulation (Property 2)
+    - **Property 2: Per-Payer Credit Accumulation**
+    - In `src/lib/__tests__/balances-multi-payer.property.test.ts`
+    - Assert: each payer's `paid` total equals their `ExpensePaidBy.amount`
+    - **Validates: Requirements 3.1, 1.3**
+
+  - [x] 2.6 Write property test: PaidFor Independence (Property 3)
+    - **Property 3: PaidFor Independence from Payer Distribution**
+    - Assert: `paidFor` values are identical regardless of payer distribution (same expense total, same split)
+    - **Validates: Requirements 3.2**
+
+  - [x] 2.7 Write property test: Single-Payer Backward Compatibility (Property 4)
+    - **Property 4: Single-Payer Backward Compatibility**
+    - Assert: single-payer expense produces identical balances to legacy computation
+    - **Validates: Requirements 3.4**
+
+- [x] 3. Core logic — activity diff
+  - [x] 3.1 Add `paidBy` field tracking to activity diff
+    - Modify `src/lib/activity-diff.ts` — add detection of `paidBy` changes in `computeExpenseChanges`
+    - Serialize old/new payer state as JSON array of `{userId, amount}` objects
+    - Record creation change when expense is new (oldValue: null, newValue: payer list)
+    - Skip recording when single-payer stays the same user and amount
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+  - [x] 3.2 Write unit tests for activity diff payer changes
+    - Extend `src/lib/activity-diff.test.ts`:
+      - Adding a second payer generates a `paidBy` change
+      - Changing payer amounts generates a change
+      - No change when payers/amounts are identical
+      - Creation records initial payer set
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+  - [x] 3.3 Write property test: Activity Diff Payer Change Detection (Property 5)
+    - **Property 5: Activity Diff Payer Change Detection**
+    - Create `src/lib/__tests__/activity-diff-multi-payer.property.test.ts`
+    - Assert: diff records change iff (userId, amount) sets differ; serialized values round-trip
+    - **Validates: Requirements 5.1, 5.2, 5.4**
+
+- [x] 4. Checkpoint — Schema and core logic
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 5. Form schema and validation
+  - [x] 5.1 Add `paidByEntrySchema` and update `expenseFormSchema`
+    - Modify `src/lib/schemas.ts`:
+      - Add `paidByEntrySchema = z.object({ participant: z.string().min(1), amount: z.union([z.number(), z.string().transform(expressionToNumber)]).refine(a => a > 0, 'paidByAmountPositive') })`
+      - Change `paidBy` field from `z.string()` to `z.array(paidByEntrySchema).min(1)` — always an array, no union with string
+      - Add superRefine: if `isReimbursement` and `paidBy` array has length > 1, issue error
+      - Add superRefine: validate sum of payer amounts equals `amount`
+    - _Requirements: 2.7, 4.1, 11.1, 11.2, 11.3_
+
+  - [x] 5.2 Write unit tests for form schema validation
+    - Extend or create tests for `expenseFormSchema`:
+      - Valid: array with one payer whose amount = total
+      - Valid: array with two payers whose amounts sum to total
+      - Invalid: payer amount ≤ 0
+      - Invalid: payer amounts sum ≠ total
+      - Invalid: reimbursement with >1 payer in array
+      - Invalid: empty array
+    - _Requirements: 2.7, 4.1, 11.1, 11.2, 11.3_
+
+- [x] 6. tRPC procedures
+  - [x] 6.1 Update create expense procedure for multi-payer
+    - Modify `src/trpc/routers/groups/expenses/create.procedure.ts`:
+      - Accept `paidBy` as `Array<{participant, amount}>`
+      - Validate all participant IDs are group members (BAD_REQUEST if not)
+      - Validate sum of amounts equals expense total
+      - Validate no duplicate userIds
+      - Create `ExpensePaidBy` rows in same transaction
+      - Set deprecated `paidById` to first payer's ID
+    - _Requirements: 1.3, 1.4, 1.6, 11.4, 11.5_
+
+  - [x] 6.2 Update update expense procedure for multi-payer
+    - Modify `src/trpc/routers/groups/expenses/update.procedure.ts`:
+      - Accept new `paidBy` array
+      - Delete existing `ExpensePaidBy` rows and recreate (upsert pattern)
+      - Same validations as create (group membership, sum, duplicates)
+      - Update deprecated `paidById` to first payer's ID
+      - Pass old/new payer data to activity diff
+    - _Requirements: 1.3, 1.4, 1.6, 5.1, 11.4, 11.5_
+
+  - [x] 6.3 Update recurring expense materialization
+    - Find the recurring expense materialization logic and copy `ExpensePaidBy` rows from source to new instance
+    - Future materializations use updated payers; existing instances unchanged
+    - _Requirements: 12.1, 12.2, 12.3_
+
+  - [x] 6.4 Write unit tests for tRPC validation
+    - Test create procedure rejects: non-member userId, amount mismatch, duplicate payer, empty array
+    - Test create procedure accepts: valid multi-payer, valid single-payer
+    - Test update procedure: payer change triggers activity log
+    - _Requirements: 1.6, 11.4, 11.5_
+
+- [x] 7. Checkpoint — API layer complete
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 8. UI — PayerSelector component
+  - [x] 8.1 Create PayerSelector component
+    - Create `src/components/payer-selector.tsx`
+    - Props: `participants`, `value` (PayerEntry[]), `onChange`, `expenseTotal`, `currency`, `locale`, `disabled`, `isReimbursement`
+    - Render one row per payer: participant dropdown (using existing `expense-participant-picker` pattern) + `CurrencyAmountInput`
+    - "Add payer" button: appends row (disabled when all participants used or `isReimbursement`)
+    - Remove button on each row (disabled when only 1 payer)
+    - Running total with mismatch indicator (red badge when ≠ expense total)
+    - "Split evenly" button: redistributes expense total equally among current payers (visible when mismatch detected)
+    - When single payer, auto-fill amount to match expense total
+    - Prevent duplicate participant selection (filter available options)
+    - Support arithmetic expressions in amount inputs (reuse `CurrencyAmountInput`)
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.8, 2.9, 2.10, 4.1, 4.2_
+
+  - [x] 8.2 Add i18n keys for PayerSelector
+    - Add keys to ALL 19 locale files (`messages/*.json`):
+      - `Expenses.paidBy.addPayer`, `Expenses.paidBy.removePayer`, `Expenses.paidBy.splitEvenly`, `Expenses.paidBy.total`, `Expenses.paidBy.mismatch`, `Expenses.paidBy.overpayment`, `Expenses.paidBy.underpayment`, `Expenses.paidBy.reimbursementSingleOnly`, `Expenses.paidBy.amountPositive`
+    - _Requirements: 2.6, 2.7, 2.10, 4.2, 11.1, 11.2, 11.3_
+
+  - [x] 8.3 Integrate PayerSelector into ExpenseForm
+    - Modify `src/app/groups/[groupId]/expenses/expense-form.tsx`:
+      - Replace single "Paid by" `<Select>` with `<PayerSelector>` component
+      - Wire form state: `paidBy` field now holds array of `{participant, amount}`
+      - When `isReimbursement` toggled on, collapse to single payer
+      - Handle expense total changes: retain payer amounts, show mismatch (Requirement 2.10)
+      - Default to current user as single payer with full amount
+    - _Requirements: 2.1, 2.2, 2.3, 2.10_
+
+  - [x] 8.4 Update ExpenseForm submission to pass multi-payer data
+    - Ensure form submission transforms `paidBy` array into the format expected by tRPC create/update procedures
+    - When editing existing expense, populate PayerSelector from `expense.payers` data
+    - _Requirements: 2.1, 1.3_
+
+  - [x] 8.5 Update expense detail, expense card, and settlements UI to show multi-payer info
+    - In expense detail view: show "Paid by A (€50) and B (€30)" instead of single payer name
+    - In expense card/list: show abbreviated multi-payer label (e.g. "A, B" or "A +1")
+    - In settlements/balances UI: credits display correctly per payer
+    - In friend timeline: no changes needed (friend expenses remain single-payer in MVP)
+    - _Requirements: 3.1, 2.11_
+
+- [x] 9. Import — Splitwise CSV
+  - [x] 9.1 Update Splitwise CSV importer for multi-payer
+    - Modify `src/lib/splitwise-import.ts`:
+      - Detect multiple positive user-column values in a CSV row
+      - Create `paidBy` array using each user's positive column value directly as their amount (validate against real Splitwise CSV before finalizing)
+      - Adjust last payer's amount to reconcile rounding differences
+      - Single positive column: single-payer entry (backward-compatible)
+    - _Requirements: 7.1, 7.2, 7.3, 7.4_
+
+  - [x] 9.2 Update `import-splitwise.procedure.ts` to write ExpensePaidBy rows
+    - Modify `src/trpc/routers/groups/expenses/import-splitwise.procedure.ts` to pass `paidBy` array to createExpense
+    - _Requirements: 7.1_
+
+  - [x] 9.3 Write unit tests for Splitwise multi-payer import
+    - Extend `src/lib/splitwise-import.test.ts`:
+      - Row with 2 positive columns → 2 payers with amounts matching column values
+      - Row with 1 positive column → single payer
+      - Rounding mismatch → last payer adjusted
+    - _Requirements: 7.1, 7.2, 7.3, 7.4_
+
+  - [x] 9.4 Write property test: Splitwise Multi-Payer Import (Property 8)
+    - **Property 8: Splitwise Multi-Payer Import**
+    - Create `src/lib/__tests__/splitwise-import-multi-payer.property.test.ts`
+    - Assert: K positive columns → K payers; sum equals row cost exactly
+    - **Validates: Requirements 7.1, 7.3, 7.4**
+
+- [x] 10. Import — Knots JSON
+  - [x] 10.1 Update Knots JSON import for multi-payer
+    - Modify `src/lib/knots-import.ts`:
+      - Accept `paidBy` array in expense JSON schema
+      - Legacy fallback: if no `paidBy` array, create single entry from `paidById` + full amount
+      - Validate payer userIds are group participants (reject with descriptive error if not)
+    - _Requirements: 8.1, 8.2, 8.3_
+
+  - [x] 10.2 Update `import-knots.procedure.ts` to write ExpensePaidBy rows
+    - Modify `src/trpc/routers/groups/expenses/import-knots.procedure.ts` to pass parsed `paidBy` array
+    - _Requirements: 8.1_
+
+  - [x] 10.3 Write unit tests for Knots JSON multi-payer import
+    - Extend `src/lib/knots-import.test.ts`:
+      - JSON with `paidBy` array → correct ExpensePaidBy entries
+      - Legacy JSON (only `paidById`) → single-payer entry
+      - Unknown userId in `paidBy` → descriptive error
+    - _Requirements: 8.1, 8.2, 8.3_
+
+  - [x] 10.4 Write property test: Knots JSON Multi-Payer Import (Property 9)
+    - **Property 9: Knots JSON Multi-Payer Import**
+    - Create `src/lib/__tests__/knots-import-multi-payer.property.test.ts`
+    - Assert: M entries in `paidBy` array → M ExpensePaidBy rows with matching data
+    - **Validates: Requirements 8.1**
+
+  - [x] 10.5 Write property test: Payer UserId Validation (Property 10)
+    - **Property 10: Payer UserId Validation**
+    - In `src/lib/__tests__/knots-import-multi-payer.property.test.ts`
+    - Assert: non-member userId → BAD_REQUEST rejection
+    - **Validates: Requirements 1.6, 8.3, 11.4, 11.5**
+
+- [x] 11. Checkpoint — Imports complete
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 12. Export — CSV
+  - [x] 12.1 Update CSV export for multi-payer
+    - Modify `src/app/groups/[groupId]/expenses/export/csv/route.ts`:
+      - Compute per-participant column: payer credit (positive) minus beneficiary debit (negative)
+      - Net amount when participant is both payer and beneficiary
+      - Single-payer expenses produce identical output to current format
+    - _Requirements: 9.1, 9.2, 9.3_
+
+  - [x] 12.2 Write property test: CSV Export Per-Participant Values (Property 11)
+    - **Property 11: CSV Export Per-Participant Values**
+    - Create `src/lib/__tests__/export-multi-payer.property.test.ts`
+    - Assert: sum of all participant columns equals zero
+    - **Validates: Requirements 9.1, 9.2**
+
+  - [x] 12.3 Write property test: CSV Export Single-Payer Backward Compatibility (Property 12)
+    - **Property 12: CSV Export Single-Payer Backward Compatibility**
+    - In `src/lib/__tests__/export-multi-payer.property.test.ts`
+    - Assert: single-payer CSV output is byte-identical to legacy
+    - **Validates: Requirements 9.3**
+
+- [x] 13. Export — JSON
+  - [x] 13.1 Update JSON export for multi-payer
+    - Modify `src/app/groups/[groupId]/expenses/export/json/route.ts`:
+      - Add `paidBy` array with `{userId, amount}` objects for every expense
+      - Single-payer expenses still include `paidBy` array (one entry) for consistency
+      - Retain legacy `paidById` field set to first payer's userId
+    - _Requirements: 10.1, 10.2, 10.3_
+
+  - [x] 13.2 Write property test: JSON Export PaidBy Array Presence (Property 13)
+    - **Property 13: JSON Export PaidBy Array Presence**
+    - In `src/lib/__tests__/export-multi-payer.property.test.ts`
+    - Assert: every exported expense has `paidBy` array with correct entries
+    - **Validates: Requirements 10.1, 10.2**
+
+  - [x] 13.3 Write property test: JSON Export Legacy PaidById Field (Property 14)
+    - **Property 14: JSON Export Legacy PaidById Field**
+    - In `src/lib/__tests__/export-multi-payer.property.test.ts`
+    - Assert: `paidById` equals first entry's userId in `paidBy` array
+    - **Validates: Requirements 10.3**
+
+- [ ] 14. Validation property tests
+  - [-] 14.1 Write property test: Per-Payer Amount Positivity (Property 15)
+    - **Property 15: Per-Payer Amount Positivity Validation**
+    - Create `src/lib/__tests__/validation-multi-payer.property.test.ts`
+    - Assert: zero or negative amount → rejection with inline error
+    - **Validates: Requirements 11.1**
+
+  - [-] 14.2 Write property test: No Duplicate Payer Participants (Property 17)
+    - **Property 17: No Duplicate Payer Participants**
+    - In `src/lib/__tests__/validation-multi-payer.property.test.ts`
+    - Assert: duplicate userId in paidBy → rejection
+    - **Validates: Requirements 2.5**
+
+- [ ] 15. Migration correctness tests
+  - [-] 15.1 Write property test: Migration Correctness and Idempotence (Property 6)
+    - **Property 6: Migration Correctness and Idempotence**
+    - Create `src/lib/__tests__/migration-multi-payer.property.test.ts`
+    - Assert: migration produces exactly one row per expense; repeated runs produce same state
+    - **Validates: Requirements 6.1, 6.3**
+
+  - [-] 15.2 Write property test: Migration Balance Preservation (Property 7)
+    - **Property 7: Migration Balance Preservation**
+    - In `src/lib/__tests__/migration-multi-payer.property.test.ts`
+    - Assert: net balance for every participant is identical before and after migration
+    - **Validates: Requirements 6.4**
+
+- [ ] 16. Recurring expense property test
+  - [-] 16.1 Write property test: Recurring Expense PaidBy Propagation (Property 16)
+    - **Property 16: Recurring Expense PaidBy Propagation**
+    - Create `src/lib/__tests__/recurring-multi-payer.property.test.ts`
+    - Assert: materialized instance has identical payer rows as source
+    - **Validates: Requirements 12.1, 12.2**
+
+- [x] 17. Final checkpoint
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- **MVP scope for PBT:** Properties 1–4 (balances) + 6–7 (migration) are the priority for the first PR. The rest can be deferred.
+- Unit tests validate specific examples and edge cases
+- The deprecated `paidById` column is retained throughout for rollback safety
+- All amounts are integer minor currency units (group currency) — no floating point
+- The migration (task 1.3) is idempotent and safe to re-run
+- Multi-payer is **group expenses only** in the MVP — direct (friend) expenses remain single-payer
+- `paidBy` schema is **always array** — no union with string
+- Relation name on Expense model: `payers` (not `paidByMulti`)
+- **Splitwise import**: validate against a real exported CSV before finalizing the column-to-amount mapping logic
+- **Currency conversion interaction**: conversion happens before payer distribution — all payer amounts are in group currency
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["1.2"] },
+    { "id": 2, "tasks": ["1.3", "1.4"] },
+    { "id": 3, "tasks": ["2.1", "3.1", "5.1"] },
+    { "id": 4, "tasks": ["2.2", "2.3", "3.2", "5.2"] },
+    { "id": 5, "tasks": ["2.4", "2.5", "2.6", "2.7", "3.3"] },
+    { "id": 6, "tasks": ["6.1", "6.2", "6.3"] },
+    { "id": 7, "tasks": ["6.4", "8.1", "8.2"] },
+    { "id": 8, "tasks": ["8.3", "9.1", "10.1"] },
+    { "id": 9, "tasks": ["8.4", "9.2", "9.3", "10.2", "10.3"] },
+    { "id": 10, "tasks": ["9.4", "10.4", "10.5"] },
+    { "id": 11, "tasks": ["12.1", "13.1"] },
+    { "id": 12, "tasks": ["12.2", "12.3", "13.2", "13.3"] },
+    { "id": 13, "tasks": ["14.1", "14.2", "15.1", "15.2", "16.1"] }
+  ]
+}
+```

--- a/.kiro/specs/paid-by-split-modes/.config.kiro
+++ b/.kiro/specs/paid-by-split-modes/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "d48102d9-3d3a-4352-bd43-8fa8fc3e3d20", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/paid-by-split-modes/design.md
+++ b/.kiro/specs/paid-by-split-modes/design.md
@@ -1,0 +1,77 @@
+# Design Document: paid-by-split-modes
+
+## Overview
+
+Replace the current "add payer row" Paid by UX with Spliit-style Choice Cards: Single payer vs Multiple payers (Evenly / By shares / By percentage / By amount). Modes are UI-only; the form and API continue to use `paidBy: Array<{ participant, amount }>`. Builds on `multi-payer-expenses` and shadcn `Field` + `RadioGroup` Choice Cards.
+
+## Architecture
+
+```mermaid
+flowchart TD
+  Mode[Payer_Mode UI state] --> Compute[Digit_Aware_Split / amount inputs]
+  Compute --> Entries[paidBy Payer_Entry array]
+  Entries --> Schema[expenseFormSchema]
+  Schema --> API[ExpensePaidBy rows]
+```
+
+### Design Decisions
+
+1. **No `paidBySplitMode` column** — Absolute amounts are the source of truth. Edit of multi-payer expenses opens as `by_amount` to avoid re-deriving an ambiguous mode.
+2. **shadcn Choice Cards** — `FieldLabel` wrapping `Field` + `RadioGroupItem` for the selectable cards; nested Select / Checkbox / CurrencyAmountInput inside the selected card.
+3. **Shared digit-aware helper** — Extract `distributeEqualAmountShares`-style math to `src/lib/distribute-amount.ts` for payer (and reuse-ready) splits.
+4. **`singlePayerOnly` prop** — Friend/hybrid floating create and reimbursements force Single mode (already partially wired).
+
+## Components and Interfaces
+
+### `distribute-amount.ts`
+
+```typescript
+export function distributeEqualAmounts(
+  totalMajor: number,
+  count: number,
+  decimalDigits: number,
+): number[]
+
+export function distributeWeightedAmounts(
+  totalMajor: number,
+  weights: number[],
+  decimalDigits: number,
+): number[]
+```
+
+### `PayerSelector` modes
+
+| Mode            | Controls                | Amount emission                           |
+| --------------- | ----------------------- | ----------------------------------------- |
+| `single`        | One Select              | `[{ participant, amount: expenseTotal }]` |
+| `evenly`        | Participant checkboxes  | Equal Digit_Aware_Split among checked     |
+| `by_shares`     | Checkbox + share input  | Weights → `distributeWeightedAmounts`     |
+| `by_percentage` | Checkbox + % input      | Must sum 100 → weighted amounts           |
+| `by_amount`     | Checkbox + amount input | Absolute amounts; mismatch badge          |
+
+### Props
+
+```typescript
+interface PayerSelectorProps {
+  participants: Array<{ id: string; name: string }>
+  value: PayerEntry[]
+  onChange: (payers: PayerEntry[]) => void
+  expenseTotal: number
+  currency: Currency
+  locale: Locale
+  disabled?: boolean
+  isReimbursement?: boolean
+  singlePayerOnly?: boolean
+}
+```
+
+## Error Handling
+
+- By amount mismatch: existing Zod `paidByAmountSum` + UI badge with `formatCurrency(..., minor)`.
+- By percentage not summing to 100: keep amounts at last valid distribution or zero-fill until valid; form validation still enforces amount sum on submit.
+- Duplicate participants: schema `paidByDuplicateParticipants` + UI prevents selecting the same id twice.
+
+## Testing
+
+- Unit tests for `distributeEqualAmounts` and `distributeWeightedAmounts`.
+- PayerSelector behavior: single mode emits one entry with full total (tested via helper + mode transition logic where practical).

--- a/.kiro/specs/paid-by-split-modes/requirements.md
+++ b/.kiro/specs/paid-by-split-modes/requirements.md
@@ -1,0 +1,78 @@
+# Requirements Document
+
+## Introduction
+
+Redesign the group expense "Paid by" UI to match the Spliit Cloud pattern: a Choice Card selector for **Single payer** versus **Multiple payers**, with multiple-payer modes (Evenly, By shares, By percentage, By amount). The persisted data model remains `paidBy: Array<{ participant, amount }>` from `multi-payer-expenses` — split modes exist only in the UI to compute those amounts. No new Prisma fields.
+
+## Glossary
+
+- **Payer_Selector**: The form control (`PayerSelector`) that collects who paid and how much each contributed.
+- **Payer_Mode**: UI-only mode: `single`, `evenly`, `by_shares`, `by_percentage`, or `by_amount`.
+- **Expense_Total**: The expense amount field value (major currency units in the form).
+- **Payer_Entry**: `{ participant: string; amount: number }` in the form; persisted as `ExpensePaidBy` after minor-unit conversion.
+- **Choice_Card**: A selectable card composed with shadcn `Field` + `RadioGroup` that reveals nested controls when selected.
+- **Digit_Aware_Split**: Integer division in minor currency units with remainder distribution so major-unit totals sum exactly.
+
+## Requirements
+
+### Requirement 1: Single vs Multiple Choice Cards
+
+**User Story:** As a user, I want a clear Single vs Multiple payers choice, so that the common single-payer case stays simple and multi-payer is intentional.
+
+#### Acceptance Criteria
+
+1. WHEN the user opens the group Expense_Form Paid by section, THE Payer_Selector SHALL present Choice_Cards grouped under Single and Multiple payers.
+2. WHEN Single payer is selected, THE Payer_Selector SHALL show one participant selector and set that payer's amount to the Expense_Total.
+3. WHEN a Multiple payers mode is selected, THE Payer_Selector SHALL allow selecting which participants paid and collect contribution inputs for that mode.
+4. WHEN `singlePayerOnly` is true OR the expense is a reimbursement, THE Payer_Selector SHALL only offer Single payer and SHALL prevent adding additional payers.
+
+### Requirement 2: Multiple Payer Modes
+
+**User Story:** As a user, I want to distribute what each payer contributed using evenly / shares / percentage / amount, so that I can match how we actually paid without manual cent math for common cases.
+
+#### Acceptance Criteria
+
+1. THE Payer_Selector SHALL offer Multiple payers modes: Evenly, By shares, By percentage, and By amount.
+2. WHEN Evenly is selected and N participants are toggled on, THE Payer_Selector SHALL set each selected payer's amount via Digit_Aware_Split of the Expense_Total.
+3. WHEN By shares is selected, THE Payer_Selector SHALL accept a positive share weight per selected payer and convert weights to amounts via Digit_Aware_Split proportional to weights.
+4. WHEN By percentage is selected, THE Payer_Selector SHALL accept percentages per selected payer that must sum to 100 and convert them to amounts via Digit_Aware_Split.
+5. WHEN By amount is selected, THE Payer_Selector SHALL accept an absolute amount per selected payer and display a mismatch indicator when the sum does not equal the Expense_Total.
+6. WHEN editing an expense with more than one Payer_Entry, THE Payer_Selector SHALL open in By amount mode so stored amounts are preserved.
+7. WHEN editing an expense with exactly one Payer_Entry, THE Payer_Selector SHALL open in Single payer mode.
+
+### Requirement 3: Persistence Contract
+
+**User Story:** As a developer, I want the form to always submit absolute payer amounts, so that the existing multi-payer API and balances keep working without a new DB column.
+
+#### Acceptance Criteria
+
+1. THE Payer_Selector SHALL always emit `paidBy` as an array of Payer_Entry with absolute amounts (major units in the form).
+2. THE system SHALL NOT persist Payer_Mode to the database.
+3. THE sum of emitted payer amounts SHALL equal the Expense_Total before successful validation (except while the user is mid-edit in By amount with a visible mismatch).
+
+### Requirement 4: Digit-Aware Amount Math
+
+**User Story:** As a user, I want even splits to conserve cents, so that €100 / 3 does not become 34+33+33 in euros.
+
+#### Acceptance Criteria
+
+1. WHEN distributing the Expense_Total across payers, THE Payer_Selector SHALL convert to minor units, divide with integer arithmetic, distribute remainders, then convert back to major units.
+2. THE Digit_Aware_Split helper SHALL be unit-tested for equal splits and weighted splits.
+
+### Requirement 5: Friend / Hybrid Scope
+
+**User Story:** As a user creating a friend or hybrid expense, I want only single-payer Paid by, so that APIs that only store one payer cannot silently drop multi-payer input.
+
+#### Acceptance Criteria
+
+1. WHEN FloatingCreateExpense has any friends selected, THE Expense_Form SHALL pass `singlePayerOnly` so only Single payer is available.
+2. WHEN creating a group-only expense (no friends), THE Expense_Form SHALL allow Multiple payers modes.
+
+### Requirement 6: Internationalization
+
+**User Story:** As a user, I want Paid by mode labels localized, so that the feature works in all supported locales.
+
+#### Acceptance Criteria
+
+1. THE Payer_Selector section headings, mode titles, and mode descriptions SHALL use i18n keys under `Expenses.paidBy`.
+2. WHEN a locale translation is missing, THE UI SHALL fall back to the English default.

--- a/.kiro/specs/paid-by-split-modes/tasks.md
+++ b/.kiro/specs/paid-by-split-modes/tasks.md
@@ -1,0 +1,32 @@
+# Implementation Plan: paid-by-split-modes
+
+## Overview
+
+Spliit-style Paid by Choice Cards on top of the existing multi-payer amount array. UI modes compute absolute amounts; no schema migration.
+
+## Tasks
+
+- [x] 1. Digit-aware distribution helper
+  - [x] 1.1 Create `src/lib/distribute-amount.ts` with `distributeEqualAmounts` and `distributeWeightedAmounts`
+  - [x] 1.2 Unit tests in `src/lib/distribute-amount.test.ts`
+    - _Requirements: 4.1, 4.2_
+
+- [x] 2. i18n for Paid by modes
+  - [x] 2.1 Add `Expenses.paidBy` keys for section labels, mode titles, and descriptions to all locale files
+    - _Requirements: 6.1, 6.2_
+
+- [x] 3. Rewrite PayerSelector
+  - [x] 3.1 Compose Choice Cards with `Field` + `RadioGroup` (Single + Multiple modes)
+  - [x] 3.2 Implement mode behaviors (evenly / shares / percentage / amount) emitting `paidBy` amounts
+  - [x] 3.3 Honor `singlePayerOnly` and `isReimbursement` (Single only)
+  - [x] 3.4 Infer initial mode from `value.length` (1 → single, else → by_amount)
+    - _Requirements: 1.1–1.4, 2.1–2.7, 3.1–3.3_
+
+- [x] 4. Wire form / floating create
+  - [x] 4.1 Ensure ExpenseForm passes `singlePayerOnly` for friend/hybrid paths
+  - [x] 4.2 Keep single-payer amount sync with expense total on the form
+    - _Requirements: 5.1, 5.2_
+
+- [x] 5. Tests and checkpoint
+  - [x] 5.1 Confirm helper tests + schema still pass; typecheck clean
+    - _Requirements: 4.2_

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "A inicis d'aquest any",
       "lastYear": "L'any passat",
       "older": "Més antics"
+    },
+    "paidBy": {
+      "addPayer": "Afegir pagador",
+      "removePayer": "Eliminar pagador",
+      "splitEvenly": "Dividir equitativament",
+      "total": "Total",
+      "mismatch": "Discrepància d'import",
+      "overpayment": "Sobrepagament de {amount}",
+      "underpayment": "Pagament insuficient de {amount}",
+      "reimbursementSingleOnly": "Els reemborsaments només admeten un pagador",
+      "amountPositive": "L'import ha de ser positiu",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Debuda per <strong>{paidBy}</strong> para <paidFor></paidFor>",
     "yourBalance": "El teu balanç: balance:",
     "notInvolved": "You are not involved",
-    "close": "Tanca"
+    "close": "Tanca",
+    "paidByMultiple": "Pagada per <strong>{paidBy}</strong> per a <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Els meus grups",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Pagat per",
         "placeholder": "Select a participant",
-        "description": "Selecciona la participant que ha pagat la despesa."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Expense Recurrence",
@@ -541,7 +570,11 @@
     "paidForMin1": "La despesa ha de ser pagada com a mínim per a una participant",
     "noZeroShares": "Totes les participacions han de ser superiors a 0",
     "amountSum": "La suma dels imports ha de ser igual a la suma de la despesa",
-    "percentageSum": "La suma dels percentatges ha de ser igual a 100"
+    "percentageSum": "La suma dels percentatges ha de ser igual a 100",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Cercar categoria...",

--- a/messages/cs-CZ.json
+++ b/messages/cs-CZ.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "Dříve tento rok",
       "lastYear": "Minulý rok",
       "older": "Starší"
+    },
+    "paidBy": {
+      "addPayer": "Přidat plátce",
+      "removePayer": "Odebrat plátce",
+      "splitEvenly": "Rozdělit rovnoměrně",
+      "total": "Celkem",
+      "mismatch": "Nesoulad částky",
+      "overpayment": "Přeplatek o {amount}",
+      "underpayment": "Nedoplatek o {amount}",
+      "reimbursementSingleOnly": "Náhrady podporují pouze jednoho plátce",
+      "amountPositive": "Částka musí být kladná",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Obdržel/a <strong>{paidBy}</strong> od <paidFor></paidFor>",
     "yourBalance": "Váš zůstatek:",
     "notInvolved": "You are not involved",
-    "close": "Zavřít"
+    "close": "Zavřít",
+    "paidByMultiple": "Zaplatil/a <strong>{paidBy}</strong> za <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Moje skupiny",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Zaplatil/a",
         "placeholder": "Select a participant",
-        "description": "Vyberte účastníka, který výdaj zaplatil."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Opakování výdaje",
@@ -541,7 +570,11 @@
     "paidForMin1": "Výdaj musí být zaplacen alespoň za jednoho účastníka.",
     "noZeroShares": "Všechny podíly musí být větší než 0.",
     "amountSum": "Součet částek se musí rovnat částce výdaje.",
-    "percentageSum": "Součet procent musí být 100."
+    "percentageSum": "Součet procent musí být 100.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Hledat kategorii...",

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "Dieses Jahr",
       "lastYear": "Letztes Jahr",
       "older": "Älter"
+    },
+    "paidBy": {
+      "addPayer": "Zahler hinzufügen",
+      "removePayer": "Zahler entfernen",
+      "splitEvenly": "Gleichmäßig aufteilen",
+      "total": "Gesamt",
+      "mismatch": "Betragsabweichung",
+      "overpayment": "Überzahlung von {amount}",
+      "underpayment": "Unterzahlung von {amount}",
+      "reimbursementSingleOnly": "Erstattungen unterstützen nur einen Zahler",
+      "amountPositive": "Betrag muss positiv sein",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Empfangen von <strong>{paidBy}</strong> für <paidFor></paidFor>",
     "yourBalance": "Deine Bilanz:",
     "notInvolved": "Du bist nicht involviert",
-    "close": "Schließen"
+    "close": "Schließen",
+    "paidByMultiple": "Gezahlt von <strong>{paidBy}</strong> für <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Meine Gruppen",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Gezahlt von",
         "placeholder": "Wähle ein Mitglied",
-        "description": "Wähle das Mitglied, das die Ausgabe bezahlt hat."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Wiederholung der Ausgabe",
@@ -541,7 +570,11 @@
     "paidForMin1": "Die Ausgabe muss mindestens für ein Mitglied bezahlt werden.",
     "noZeroShares": "Alle Anteile müssen größer als 0 sein.",
     "amountSum": "Die Summe der Beträge muss dem Betrag der Ausgabe entsprechen.",
-    "percentageSum": "Die Summe der prozentualen Anteile muss 100 ergeben."
+    "percentageSum": "Die Summe der prozentualen Anteile muss 100 ergeben.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Nach Kategorie suchen...",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -48,15 +48,44 @@
       "earlierThisYear": "Earlier this year",
       "lastYear": "Last year",
       "older": "Older"
+    },
+    "paidBy": {
+      "addPayer": "Add payer",
+      "removePayer": "Remove payer",
+      "splitEvenly": "Split evenly",
+      "total": "Total",
+      "mismatch": "Amount mismatch",
+      "overpayment": "Overpayment by {amount}",
+      "underpayment": "Underpayment by {amount}",
+      "reimbursementSingleOnly": "Reimbursements support only one payer",
+      "amountPositive": "Amount must be positive",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
     "paidBy": "Paid by <strong>{paidBy}</strong> for <paidFor></paidFor>",
+    "paidByMultiple": "Paid by <strong>{paidBy}</strong> for <paidFor></paidFor>",
     "everyone": "everyone",
     "receivedBy": "Received by <strong>{paidBy}</strong> for <paidFor></paidFor>",
     "yourBalance": "Your balance:",
     "notInvolved": "You are not involved",
-    "close": "Close"
+    "close": "Close",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "ExpenseDetail": {
     "backToExpenses": "Back to expenses",
@@ -80,6 +109,9 @@
     "receiptUploadSuccess": "Receipt attached.",
     "paidAmount": "{name} paid {amount}",
     "youPaidAmount": "You paid {amount}",
+    "paidAmountMultiple": "{name} paid {amount}",
+    "youPaidAmountMultiple": "You paid {amount}",
+    "multiPayerSeparator": " and ",
     "paidYou": "{name} paid you {amount}",
     "youPaidRecipient": "You paid {name} {amount}",
     "payerPaidPayee": "{payer} paid {payee} {amount}",
@@ -237,7 +269,7 @@
       "paidByField": {
         "label": "Paid by",
         "placeholder": "Select a participant",
-        "description": "Select the participant who paid the expense."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Expense Recurrence",
@@ -610,6 +642,10 @@
     "paidToRequired": "You must select who received the payment.",
     "paidToDifferent": "The payer and recipient must be different people.",
     "paidForMin1": "The expense must be paid for at least one participant.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer.",
     "noZeroShares": "All shares must be higher than 0.",
     "amountSum": "Sum of amounts must equal the expense amount.",
     "percentageSum": "Sum of percentages must equal 100."

--- a/messages/es.json
+++ b/messages/es.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "A principios de este año",
       "lastYear": "El año pasado",
       "older": "Más antiguos"
+    },
+    "paidBy": {
+      "addPayer": "Añadir pagador",
+      "removePayer": "Eliminar pagador",
+      "splitEvenly": "Dividir en partes iguales",
+      "total": "Total",
+      "mismatch": "Discrepancia de monto",
+      "overpayment": "Sobrepago de {amount}",
+      "underpayment": "Pago insuficiente de {amount}",
+      "reimbursementSingleOnly": "Los reembolsos solo admiten un pagador",
+      "amountPositive": "El monto debe ser positivo",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Recibido por <strong>{paidBy}</strong> para <paidFor></paidFor>",
     "yourBalance": "Tu balance:",
     "notInvolved": "You are not involved",
-    "close": "Cerrar"
+    "close": "Cerrar",
+    "paidByMultiple": "Pagado por <strong>{paidBy}</strong> para <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Mis grupos",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Pagado por",
         "placeholder": "Select a participant",
-        "description": "Seleccione el participante que pagó el gasto."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Recurrencia",
@@ -541,7 +570,11 @@
     "paidForMin1": "El gasto debe ser pagado por al menos un participante",
     "noZeroShares": "Todas las participaciones deben ser superiores a 0",
     "amountSum": "La suma de los importes debe ser igual al importe del gasto",
-    "percentageSum": "Suma de porcentajes debe ser igual a 100"
+    "percentageSum": "Suma de porcentajes debe ser igual a 100",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Buscar categoría...",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "Aikaisemmin tänä vuonna",
       "lastYear": "Viime vuonna",
       "older": "Vanhemmat"
+    },
+    "paidBy": {
+      "addPayer": "Lisää maksaja",
+      "removePayer": "Poista maksaja",
+      "splitEvenly": "Jaa tasan",
+      "total": "Yhteensä",
+      "mismatch": "Summa ei täsmää",
+      "overpayment": "Ylimaksu {amount}",
+      "underpayment": "Alimaksu {amount}",
+      "reimbursementSingleOnly": "Hyvitykset tukevat vain yhtä maksajaa",
+      "amountPositive": "Summan on oltava positiivinen",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "<strong>{paidBy}</strong> sai rahaa {forCount, plural, =1 {henkilön} other {henkilöiden}} <paidFor></paidFor> puolesta",
     "yourBalance": "Saldosi:",
     "notInvolved": "You are not involved",
-    "close": "Sulje"
+    "close": "Sulje",
+    "paidByMultiple": "<strong>{paidBy}</strong> maksoi {forCount, plural, =1 {henkilön} other {henkilöiden}} <paidFor></paidFor> puolesta",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Omat ryhmät",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Maksaja",
         "placeholder": "Select a participant",
-        "description": "Valitse kuka maksoi kulun."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Expense Recurrence",
@@ -541,7 +570,11 @@
     "paidForMin1": "Valitse vähintään yksi osallistuja.",
     "noZeroShares": "Jokaisen osuuden täytyy olla suurempi kuin 0.",
     "amountSum": "Osuuksien summan täytyy vastata kulun summaa.",
-    "percentageSum": "Prosenttiosuuksien summan täytyy olla 100."
+    "percentageSum": "Prosenttiosuuksien summan täytyy olla 100.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Etsi kategoriaa...",

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "Plus tôt cette année",
       "lastYear": "L'année dernière",
       "older": "Plus ancien"
+    },
+    "paidBy": {
+      "addPayer": "Ajouter un payeur",
+      "removePayer": "Supprimer le payeur",
+      "splitEvenly": "Répartir équitablement",
+      "total": "Total",
+      "mismatch": "Écart de montant",
+      "overpayment": "Surpaiement de {amount}",
+      "underpayment": "Sous-paiement de {amount}",
+      "reimbursementSingleOnly": "Les remboursements ne prennent en charge qu'un seul payeur",
+      "amountPositive": "Le montant doit être positif",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Reçu par <strong>{paidBy}</strong> pour <paidFor></paidFor>",
     "yourBalance": "Votre solde :",
     "notInvolved": "Vous n'êtes pas concerné",
-    "close": "Fermer"
+    "close": "Fermer",
+    "paidByMultiple": "Payé par <strong>{paidBy}</strong> pour <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Mes groupes",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Payé par",
         "placeholder": "Sélectionner un participant",
-        "description": "Sélectionnez le participant qui a réglé la dépense."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Récurrence de la dépense",
@@ -541,7 +570,11 @@
     "paidForMin1": "La dépense doit concerner au moins un participant.",
     "noZeroShares": "Toutes les parts doivent être supérieures à 0.",
     "amountSum": "La somme des montants doit être égale au montant de la dépense.",
-    "percentageSum": "La somme des pourcentages doit être égale à 100."
+    "percentageSum": "La somme des pourcentages doit être égale à 100.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Rechercher une catégorie…",

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "All'inizio di quest'anno",
       "lastYear": "Ultimo anno",
       "older": "Più vecchio"
+    },
+    "paidBy": {
+      "addPayer": "Aggiungi pagatore",
+      "removePayer": "Rimuovi pagatore",
+      "splitEvenly": "Dividi equamente",
+      "total": "Totale",
+      "mismatch": "Importo non corrispondente",
+      "overpayment": "Pagamento in eccesso di {amount}",
+      "underpayment": "Pagamento in difetto di {amount}",
+      "reimbursementSingleOnly": "I rimborsi supportano solo un pagatore",
+      "amountPositive": "L'importo deve essere positivo",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Ricevuto da <strong>{paidBy}</strong> per <paidFor></paidFor>",
     "yourBalance": "Il tuo saldo:",
     "notInvolved": "Non sei coinvolto",
-    "close": "Chiudi"
+    "close": "Chiudi",
+    "paidByMultiple": "Pagato da <strong>{paidBy}</strong> per <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "I miei gruppi",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Pagato da",
         "placeholder": "Seleziona un partecipante",
-        "description": "Seleziona il partecipante che ha pagato la spesa."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Spesa ricorrente",
@@ -541,7 +570,11 @@
     "paidForMin1": "La spesa deve essere pagata per almeno un partecipante.",
     "noZeroShares": "Tutti gli importi devono essere superiori a 0.",
     "amountSum": "La somma degli importi deve essere uguale all'importo della spesa.",
-    "percentageSum": "La somma delle percentuali deve essere uguale a 100."
+    "percentageSum": "La somma delle percentuali deve essere uguale a 100.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Cerca categoria...",

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "今年初め",
       "lastYear": "昨年",
       "older": "それ以前"
+    },
+    "paidBy": {
+      "addPayer": "支払者を追加",
+      "removePayer": "支払者を削除",
+      "splitEvenly": "均等に分割",
+      "total": "合計",
+      "mismatch": "金額の不一致",
+      "overpayment": "{amount} の過払い",
+      "underpayment": "{amount} の不足",
+      "reimbursementSingleOnly": "払い戻しは1人の支払者のみ対応しています",
+      "amountPositive": "金額は正の値である必要があります",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "<strong>{paidBy}</strong>が<paidFor></paidFor>のために受け取りました",
     "yourBalance": "あなたの残高:",
     "notInvolved": "You are not involved",
-    "close": "閉じる"
+    "close": "閉じる",
+    "paidByMultiple": "<strong>{paidBy}</strong>が<paidFor></paidFor>のために支払いました",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "マイグループ",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "支払者",
         "placeholder": "Select a participant",
-        "description": "支出を支払った参加者を選択してください。"
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "支出の繰り返し",
@@ -541,7 +570,11 @@
     "paidForMin1": "支出は少なくとも1人の参加者のために支払われている必要があります。",
     "noZeroShares": "すべてのシェアは0より大きくなければなりません。",
     "amountSum": "金額の合計は支出金額と一致する必要があります。",
-    "percentageSum": "パーセンテージの合計は100である必要があります。"
+    "percentageSum": "パーセンテージの合計は100である必要があります。",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "カテゴリーを検索...",

--- a/messages/nl-NL.json
+++ b/messages/nl-NL.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "Eerder dit jaar",
       "lastYear": "Vorig jaar",
       "older": "Ouder"
+    },
+    "paidBy": {
+      "addPayer": "Betaler toevoegen",
+      "removePayer": "Betaler verwijderen",
+      "splitEvenly": "Gelijk verdelen",
+      "total": "Totaal",
+      "mismatch": "Bedrag komt niet overeen",
+      "overpayment": "Teveel betaald met {amount}",
+      "underpayment": "Te weinig betaald met {amount}",
+      "reimbursementSingleOnly": "Vergoedingen ondersteunen slechts één betaler",
+      "amountPositive": "Bedrag moet positief zijn",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Ontvangen door <strong>{paidBy}</strong> voor <paidFor></paidFor>",
     "yourBalance": "Jouw balans:",
     "notInvolved": "Je bent hier niet bij betrokken",
-    "close": "Sluiten"
+    "close": "Sluiten",
+    "paidByMultiple": "Betaald door <strong>{paidBy}</strong> voor <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Mijn groepen",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Betaald door",
         "placeholder": "Selecteer een deelnemer",
-        "description": "Selecteer de deelnemer die de uitgave heeft gedaan."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Terugkerende uitgave",
@@ -541,7 +570,11 @@
     "paidForMin1": "De uitgave moet voor ten minste één deelnemer zijn gedaan.",
     "noZeroShares": "Een deel mag niet 0 zijn.",
     "amountSum": "Het totaalbedrag moet gelijk zijn aan het uitgavebedrag.",
-    "percentageSum": "Het totaalpercentage moet gelijk zijn aan 100%."
+    "percentageSum": "Het totaalpercentage moet gelijk zijn aan 100%.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Categorie zoeken…",

--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "Wcześniej w tym roku",
       "lastYear": "Poprzedni rok",
       "older": "Starsze"
+    },
+    "paidBy": {
+      "addPayer": "Dodaj płatnika",
+      "removePayer": "Usuń płatnika",
+      "splitEvenly": "Podziel równo",
+      "total": "Suma",
+      "mismatch": "Niezgodność kwoty",
+      "overpayment": "Nadpłata o {amount}",
+      "underpayment": "Niedopłata o {amount}",
+      "reimbursementSingleOnly": "Zwroty obsługują tylko jednego płatnika",
+      "amountPositive": "Kwota musi być dodatnia",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Otrzymane przez <strong>{paidBy}</strong> od <paidFor></paidFor>",
     "yourBalance": "Twjoje saldo:",
     "notInvolved": "You are not involved",
-    "close": "Zamknij"
+    "close": "Zamknij",
+    "paidByMultiple": "Opłacone przez <strong>{paidBy}</strong> dla <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Moje grupy",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Opłacone przez",
         "placeholder": "Select a participant",
-        "description": "Wybierz członka, który zapłacił."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Powtarzalnośc wydatku",
@@ -541,7 +570,11 @@
     "paidForMin1": "Wydatek musi zostać opłacony za co najmniej jednego uczestnika.",
     "noZeroShares": "Wszystkie udziały muszą być większe niż 0.",
     "amountSum": "Suma udziałów musi być równa wydatkowi.",
-    "percentageSum": "Suma procentów musi być równa 100."
+    "percentageSum": "Suma procentów musi być równa 100.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Szukaj kategorii…",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "Anteriores neste ano",
       "lastYear": "Ano passado",
       "older": "Mais antigas"
+    },
+    "paidBy": {
+      "addPayer": "Adicionar pagador",
+      "removePayer": "Remover pagador",
+      "splitEvenly": "Dividir igualmente",
+      "total": "Total",
+      "mismatch": "Valor incompatível",
+      "overpayment": "Pagamento excedente de {amount}",
+      "underpayment": "Pagamento insuficiente de {amount}",
+      "reimbursementSingleOnly": "Reembolsos suportam apenas um pagador",
+      "amountPositive": "O valor deve ser positivo",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Recebido por <strong>{paidBy}</strong> para <paidFor></paidFor>",
     "yourBalance": "Seu saldo:",
     "notInvolved": "Você não está envolvido",
-    "close": "Fechar"
+    "close": "Fechar",
+    "paidByMultiple": "Pago por <strong>{paidBy}</strong> para <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Meus grupos",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Pago por",
         "placeholder": "Selecione um participante",
-        "description": "Selecione o participante que pagou a despesa."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Recorrência da Despesa",
@@ -541,7 +570,11 @@
     "paidForMin1": "A despesa deve ser paga para pelo menos um participante.",
     "noZeroShares": "Todas as partes devem ser maiores que 0.",
     "amountSum": "A soma dos valores deve ser igual ao valor da despesa.",
-    "percentageSum": "A soma das porcentagens deve ser igual a 100."
+    "percentageSum": "A soma das porcentagens deve ser igual a 100.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Pesquisar categoria...",

--- a/messages/pt-PT.json
+++ b/messages/pt-PT.json
@@ -48,6 +48,32 @@
       "lastYear": "Ano passado",
       "older": "Mais antigas"
     },
+    "paidBy": {
+      "addPayer": "Adicionar pagador",
+      "removePayer": "Remover pagador",
+      "splitEvenly": "Dividir igualmente",
+      "total": "Total",
+      "mismatch": "Valor incompatível",
+      "overpayment": "Pagamento em excesso de {amount}",
+      "underpayment": "Pagamento em falta de {amount}",
+      "reimbursementSingleOnly": "Os reembolsos suportam apenas um pagador",
+      "amountPositive": "O valor deve ser positivo",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
+    },
     "export": "Exportar"
   },
   "ExpenseCard": {
@@ -56,7 +82,10 @@
     "yourBalance": "O teu saldo:",
     "everyone": "Todos",
     "notInvolved": "Não estás envolvido",
-    "close": "Fechar"
+    "close": "Fechar",
+    "paidByMultiple": "Pago por <strong>{paidBy}</strong> para <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "ExpenseDetail": {
     "backToExpenses": "Voltar às despesas",
@@ -80,6 +109,9 @@
     "receiptUploadSuccess": "Recibo anexado.",
     "paidAmount": "{name} pagou {amount}",
     "youPaidAmount": "Pagou {amount}",
+    "paidAmountMultiple": "{name} pagou {amount}",
+    "youPaidAmountMultiple": "Pagou {amount}",
+    "multiPayerSeparator": " e ",
     "paidYou": "{name} pagou-lhe {amount}",
     "youPaidRecipient": "Pagou {amount} a {name}",
     "payerPaidPayee": "{payer} pagou {amount} a {payee}",
@@ -232,7 +264,7 @@
       "categoryFieldDescription": "Selecciona a categoria da despesa.",
       "paidByField": {
         "label": "Pago por",
-        "description": "Selecciona o participante que pagou a despesa.",
+        "description": "Select who provided the money and how much each payer contributed.",
         "placeholder": "Selecciona um participante"
       },
       "paidFor": {
@@ -612,7 +644,11 @@
     "noZeroShares": "Todas as partes têm de ser superiores a 0.",
     "amountSum": "A soma dos valores tem de ser igual ao valor da despesa.",
     "percentageSum": "A soma das percentagens tem de ser igual a 100.",
-    "ratePositive": "A taxa tem de ser estritamente superior a zero."
+    "ratePositive": "A taxa tem de ser estritamente superior a zero.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Procurar categoria...",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "La începutul anului",
       "lastYear": "Anul trecut",
       "older": "Mai vechi"
+    },
+    "paidBy": {
+      "addPayer": "Adaugă plătitor",
+      "removePayer": "Elimină plătitor",
+      "splitEvenly": "Împarte egal",
+      "total": "Total",
+      "mismatch": "Nepotrivire de sumă",
+      "overpayment": "Plată în exces cu {amount}",
+      "underpayment": "Plată insuficientă cu {amount}",
+      "reimbursementSingleOnly": "Rambursările suportă doar un plătitor",
+      "amountPositive": "Suma trebuie să fie pozitivă",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Primit de <strong>{paidBy}</strong> pentru <paidFor></paidFor>",
     "yourBalance": "Soldul tău:",
     "notInvolved": "You are not involved",
-    "close": "Închide"
+    "close": "Închide",
+    "paidByMultiple": "Plătit de <strong>{paidBy}</strong> pentru <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Grupurile mele",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Plătit de către",
         "placeholder": "Select a participant",
-        "description": "Selectează membrul care a plătit cheltuiala."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Expense Recurrence",
@@ -541,7 +570,11 @@
     "paidForMin1": "Cheltuiala trebuie plătită pentru cel puțin un membru.",
     "noZeroShares": "Toate părțile trebuie să fie mai mari de 0.",
     "amountSum": "Suma valorilor trebuie să fie egală cu suma cheltuielilor.",
-    "percentageSum": "Suma procentajelor trebuie să fie egală cu 100."
+    "percentageSum": "Suma procentajelor trebuie să fie egală cu 100.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Căutați categorie…",

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "Ранее в этом году",
       "lastYear": "В прошлом году",
       "older": "Очень давно"
+    },
+    "paidBy": {
+      "addPayer": "Добавить плательщика",
+      "removePayer": "Удалить плательщика",
+      "splitEvenly": "Разделить поровну",
+      "total": "Итого",
+      "mismatch": "Несоответствие суммы",
+      "overpayment": "Переплата на {amount}",
+      "underpayment": "Недоплата на {amount}",
+      "reimbursementSingleOnly": "Возмещения поддерживают только одного плательщика",
+      "amountPositive": "Сумма должна быть положительной",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Получил <strong>{paidBy}</strong> за <paidFor></paidFor>",
     "yourBalance": "Изменение баланса участника:",
     "notInvolved": "You are not involved",
-    "close": "Закрыть"
+    "close": "Закрыть",
+    "paidByMultiple": "Потратил <strong>{paidBy}</strong> за <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Мои группы",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Оплативший",
         "placeholder": "Select a participant",
-        "description": "Выберите участника, который оплатил этот расход."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Expense Recurrence",
@@ -541,7 +570,11 @@
     "paidForMin1": "За этот расход должен заплатить как минимум один участник.",
     "noZeroShares": "Все доли должны быть больше 0.",
     "amountSum": "Сумма расхода должна быть равна сумме значений, распределенных между участниками.",
-    "percentageSum": "Сумма процентов должна быть равна 100."
+    "percentageSum": "Сумма процентов должна быть равна 100.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Поиск категорий...",

--- a/messages/tr-TR.json
+++ b/messages/tr-TR.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "Bu yılın başlarında",
       "lastYear": "Geçen yıl",
       "older": "Daha eski"
+    },
+    "paidBy": {
+      "addPayer": "Ödeyen ekle",
+      "removePayer": "Ödeyeni kaldır",
+      "splitEvenly": "Eşit böl",
+      "total": "Toplam",
+      "mismatch": "Tutar uyuşmazlığı",
+      "overpayment": "{amount} fazla ödeme",
+      "underpayment": "{amount} eksik ödeme",
+      "reimbursementSingleOnly": "Geri ödemeler yalnızca bir ödeyeni destekler",
+      "amountPositive": "Tutar pozitif olmalıdır",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "<strong>{paidBy}</strong> tarafından alındı, <paidFor></paidFor> için",
     "yourBalance": "Bakiyeniz:",
     "notInvolved": "You are not involved",
-    "close": "Kapat"
+    "close": "Kapat",
+    "paidByMultiple": "<strong>{paidBy}</strong> tarafından ödendi, <paidFor></paidFor> için",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Gruplarım",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Ödeyen",
         "placeholder": "Select a participant",
-        "description": "Masrafı ödeyen katılımcıyı seçin."
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Expense Recurrence",
@@ -541,7 +570,11 @@
     "paidForMin1": "Masraf en az bir katılımcı için ödenmiş olmalıdır.",
     "noZeroShares": "Tüm paylar 0'dan büyük olmalıdır.",
     "amountSum": "Tutarların toplamı masraf tutarına eşit olmalıdır.",
-    "percentageSum": "Yüzdelerin toplamı 100 olmalıdır."
+    "percentageSum": "Yüzdelerin toplamı 100 olmalıdır.",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Kategori ara...",

--- a/messages/ua-UA.json
+++ b/messages/ua-UA.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "Раніше цього року",
       "lastYear": "Минулого року",
       "older": "Старіші"
+    },
+    "paidBy": {
+      "addPayer": "Додати платника",
+      "removePayer": "Видалити платника",
+      "splitEvenly": "Розділити порівну",
+      "total": "Всього",
+      "mismatch": "Невідповідність суми",
+      "overpayment": "Переплата на {amount}",
+      "underpayment": "Недоплата на {amount}",
+      "reimbursementSingleOnly": "Відшкодування підтримують лише одного платника",
+      "amountPositive": "Сума повинна бути додатною",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "Отримано <strong>{paidBy}</strong> за <paidFor></paidFor>",
     "yourBalance": "Ваш баланс:",
     "notInvolved": "You are not involved",
-    "close": "Закрити"
+    "close": "Закрити",
+    "paidByMultiple": "Сплачено <strong>{paidBy}</strong> за <paidFor></paidFor>",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "Мої групи",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "Сплатив",
         "placeholder": "Select a participant",
-        "description": "Оберіть учасника, який сплатив"
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Expense Recurrence",
@@ -541,7 +570,11 @@
     "paidForMin1": "Витрата повинна бути сплачена принаймні для одного учасника",
     "noZeroShares": "Усі частки повинні бути більшими за 0",
     "amountSum": "Сума повинна відповідати витраті",
-    "percentageSum": "Сума відсотків повинна дорівнювати 100"
+    "percentageSum": "Сума відсотків повинна дорівнювати 100",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "Шукати категорію..",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "本年早些时候",
       "lastYear": "去年",
       "older": "更早"
+    },
+    "paidBy": {
+      "addPayer": "添加付款人",
+      "removePayer": "移除付款人",
+      "splitEvenly": "平均分摊",
+      "total": "合计",
+      "mismatch": "金额不匹配",
+      "overpayment": "多付 {amount}",
+      "underpayment": "少付 {amount}",
+      "reimbursementSingleOnly": "报销仅支持一个付款人",
+      "amountPositive": "金额必须为正数",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "<strong>{paidBy}</strong> 为 <paidFor></paidFor> 接收。",
     "yourBalance": "你的余额：",
     "notInvolved": "You are not involved",
-    "close": "关闭"
+    "close": "关闭",
+    "paidByMultiple": "<strong>{paidBy}</strong> 为 <paidFor></paidFor> 支付。",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "我的群组",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "支付自",
         "placeholder": "Select a participant",
-        "description": "选择支付这笔消费的群组成员。"
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Expense Recurrence",
@@ -541,7 +570,11 @@
     "paidForMin1": "这项消费必须支付给至少1名群组成员。",
     "noZeroShares": "所有份额必须大于0。",
     "amountSum": "金额之和必须等于消费的金额。",
-    "percentageSum": "百分比之和必须等于100。"
+    "percentageSum": "百分比之和必须等于100。",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "搜寻类别……",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -45,6 +45,32 @@
       "earlierThisYear": "今年稍早",
       "lastYear": "去年",
       "older": "更早"
+    },
+    "paidBy": {
+      "addPayer": "新增付款人",
+      "removePayer": "移除付款人",
+      "splitEvenly": "平均分攤",
+      "total": "合計",
+      "mismatch": "金額不符",
+      "overpayment": "多付 {amount}",
+      "underpayment": "少付 {amount}",
+      "reimbursementSingleOnly": "退款僅支援一位付款人",
+      "amountPositive": "金額必須為正數",
+      "singleSection": "Single",
+      "multipleSection": "Multiple payers",
+      "singleTitle": "Single payer",
+      "singleDescription": "One person covers the full expense",
+      "evenlyTitle": "Evenly",
+      "evenlyDescription": "Each pays an equal share",
+      "bySharesTitle": "By shares",
+      "bySharesDescription": "Each pays a weighted share",
+      "byPercentageTitle": "By percentage",
+      "byPercentageDescription": "Each pays a percentage",
+      "byAmountTitle": "By amount",
+      "byAmountDescription": "Each pays a fixed amount",
+      "selectPayers": "Select who paid",
+      "shareLabel": "Shares",
+      "percentageLabel": "Percent"
     }
   },
   "ExpenseCard": {
@@ -53,7 +79,10 @@
     "receivedBy": "由 <strong>{paidBy}</strong> 收取 <paidFor></paidFor>。",
     "yourBalance": "你的餘額：",
     "notInvolved": "You are not involved",
-    "close": "關閉"
+    "close": "關閉",
+    "paidByMultiple": "由 <strong>{paidBy}</strong> 支付 <paidFor></paidFor>。",
+    "multiPayerLabel": "{first}, {second}",
+    "multiPayerLabelOverflow": "{first} +{count}"
   },
   "Groups": {
     "myGroups": "我的群組",
@@ -193,7 +222,7 @@
       "paidByField": {
         "label": "支付人",
         "placeholder": "Select a participant",
-        "description": "选择支付这笔消费的群组成员。"
+        "description": "Select who provided the money and how much each payer contributed."
       },
       "recurrenceRule": {
         "label": "Expense Recurrence",
@@ -541,7 +570,11 @@
     "paidForMin1": "這筆消費必須包含至少一個成員。",
     "noZeroShares": "份額需大於 0。",
     "amountSum": "金額總計必須等於消費金額。",
-    "percentageSum": "百分比加總必須等於 100。"
+    "percentageSum": "百分比加總必須等於 100。",
+    "paidByAmountPositive": "Each payer's amount must be greater than zero.",
+    "paidByAmountSum": "Payer amounts must sum to the expense total.",
+    "paidByDuplicateParticipants": "Each payer can only appear once.",
+    "reimbursementSinglePayer": "Reimbursements support only a single payer."
   },
   "Categories": {
     "search": "搜尋類別……",

--- a/prisma/migrations/20260807004656_add_expense_paid_by/migration.sql
+++ b/prisma/migrations/20260807004656_add_expense_paid_by/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "ExpensePaidBy" (
+    "expenseId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+
+    CONSTRAINT "ExpensePaidBy_pkey" PRIMARY KEY ("expenseId","userId")
+);
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_expenseId_fkey" FOREIGN KEY ("expenseId") REFERENCES "Expense"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260807010217_backfill_expense_paid_by/migration.sql
+++ b/prisma/migrations/20260807010217_backfill_expense_paid_by/migration.sql
@@ -1,0 +1,11 @@
+-- Backfill ExpensePaidBy from existing single-payer expenses.
+-- This migration is idempotent: safe to run multiple times without creating duplicates.
+-- It handles ALL expenses regardless of groupId (including null groupId for orphaned/direct-friend expenses).
+
+INSERT INTO "ExpensePaidBy" ("expenseId", "userId", "amount")
+SELECT e."id", e."paidById", e."amount"
+FROM "Expense" e
+WHERE NOT EXISTS (
+  SELECT 1 FROM "ExpensePaidBy" epb WHERE epb."expenseId" = e."id"
+)
+ON CONFLICT ("expenseId", "userId") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,7 @@ model Expense {
   conversionRate   Decimal?
   paidBy           User              @relation("ExpensesPaidBy", fields: [paidById], references: [id])
   paidById         String
+  payers           ExpensePaidBy[]   @relation("ExpensesPaidByMulti")
   paidFor          ExpensePaidFor[]
   groupId          String?
   isReimbursement  Boolean           @default(false)
@@ -116,6 +117,16 @@ model ExpensePaidFor {
   expenseId String
   userId    String
   shares    Int     @default(1)
+
+  @@id([expenseId, userId])
+}
+
+model ExpensePaidBy {
+  expense   Expense @relation("ExpensesPaidByMulti", fields: [expenseId], references: [id], onDelete: Cascade)
+  user      User    @relation("UserExpensesPaidBy", fields: [userId], references: [id], onDelete: Cascade)
+  expenseId String
+  userId    String
+  amount    Int     // minor currency units
 
   @@id([expenseId, userId])
 }
@@ -206,6 +217,7 @@ model User {
   memberships     GroupMembership[]
   invitationsSent Invitation[]      @relation("InvitedBy")
   expensesPaidBy  Expense[]         @relation("ExpensesPaidBy")
+  paidByExpenses  ExpensePaidBy[]   @relation("UserExpensesPaidBy")
   expensesPaidFor ExpensePaidFor[]  @relation("ExpensesPaidFor")
   friendsOwned    Friend[]          @relation("FriendsOwned")
   friendsLinked   Friend[]          @relation("FriendsLinked")

--- a/src/app/groups/[groupId]/activity/format-change-value.ts
+++ b/src/app/groups/[groupId]/activity/format-change-value.ts
@@ -62,7 +62,12 @@ export function formatFieldValue(
       return formatBoolean(value, context.t)
 
     case 'paidBy':
-      return resolveParticipantName(value, context.participants)
+      return formatPaidBy(
+        value,
+        context.participants,
+        context.currency,
+        context.locale,
+      )
 
     case 'paidFor':
       return formatPaidFor(value, context.participants)
@@ -140,4 +145,34 @@ function formatCategory(
   }
   const category = categories.find((c) => c.id === parsed)
   return category ? `${category.grouping}/${category.name}` : value
+}
+
+function formatPaidBy(
+  value: string,
+  participants: Array<{ id: string; name: string }>,
+  currency: Currency,
+  locale: string,
+): string {
+  // Try parsing as JSON array (multi-payer format: [{userId, amount}, ...])
+  try {
+    const parsed: unknown = JSON.parse(value)
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      return parsed
+        .map((entry) => {
+          const e = entry as { userId?: string; amount?: number }
+          const name = resolveParticipantName(
+            String(e.userId ?? entry),
+            participants,
+          )
+          if (e.amount != null) {
+            return `${name} (${formatCurrency(currency, e.amount, locale)})`
+          }
+          return name
+        })
+        .join(', ')
+    }
+  } catch {
+    // Not JSON — treat as a plain participant ID (legacy format)
+  }
+  return resolveParticipantName(value, participants)
 }

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -46,7 +46,36 @@ function Participants({
   participantCount: number
 }) {
   const t = useTranslations('ExpenseCard')
-  const key = expense.amount > 0 ? 'paidBy' : 'receivedBy'
+
+  // Determine payer label: use payers array if multi-payer, fall back to legacy paidBy
+  const hasMultiplePayers = expense.payers && expense.payers.length > 1
+  let payerLabel: string
+  let key: string
+
+  if (expense.amount > 0) {
+    if (hasMultiplePayers) {
+      const payers = expense.payers
+      if (payers.length === 2) {
+        payerLabel = t('multiPayerLabel', {
+          first: payers[0].user.name ?? '?',
+          second: payers[1].user.name ?? '?',
+        })
+      } else {
+        payerLabel = t('multiPayerLabelOverflow', {
+          first: payers[0].user.name ?? '?',
+          count: payers.length - 1,
+        })
+      }
+      key = 'paidByMultiple'
+    } else {
+      payerLabel = expense.paidBy.name ?? '?'
+      key = 'paidBy'
+    }
+  } else {
+    payerLabel = expense.paidBy.name ?? '?'
+    key = 'receivedBy'
+  }
+
   const paidFor =
     expense.paidFor.length == participantCount && participantCount >= 4 ? (
       <strong>{t('everyone')}</strong>
@@ -61,7 +90,7 @@ function Participants({
 
   const participants = t.rich(key, {
     strong: (chunks) => <strong>{chunks}</strong>,
-    paidBy: expense.paidBy.name,
+    paidBy: payerLabel,
     paidFor: () => paidFor,
     forCount: expense.paidFor.length,
   })
@@ -106,6 +135,10 @@ export function ExpenseCard({
       amount: expense.amount,
       categoryId: expense.categoryId,
       paidById: expense.paidBy.id,
+      payers: expense.payers?.map((p) => ({
+        userId: p.userId,
+        amount: p.amount,
+      })),
       splitMode: expense.splitMode,
       isReimbursement: expense.isReimbursement,
       notes: expense.notes,

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -17,9 +17,17 @@ import {
 } from '@/components/expense-title-input'
 import { useDuplicateCheck } from '@/components/hooks/use-duplicate-check'
 import { useFormPersistence } from '@/components/hooks/use-form-persistence'
+import { PayerSelector, type PayerEntry } from '@/components/payer-selector'
 import { PreventNavigation } from '@/components/prevent-navigation'
 import { SubmitButton } from '@/components/submit-button'
 import { Button, buttonVariants } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { DialogFooter } from '@/components/ui/dialog'
 import {
@@ -451,7 +459,7 @@ export type ExpenseFormCreatePrefill = {
   category?: number
   documents?: ExpenseFormValues['documents']
   isReimbursement?: boolean
-  paidBy?: string
+  paidBy?: string | Array<{ participant: string; amount: number }>
   paidFor?: ExpenseFormValues['paidFor']
   splitMode?: ExpenseFormValues['splitMode']
   notes?: string
@@ -487,6 +495,7 @@ export function ExpenseForm({
   runtimeFeatureFlags,
   isDesktop = false,
   scrollHeader,
+  singlePayerOnly = false,
 }: {
   group: NonNullable<AppRouterOutput['groups']['get']['group']>
   expense?: AppRouterOutput['groups']['expenses']['get']['expense']
@@ -500,6 +509,7 @@ export function ExpenseForm({
   runtimeFeatureFlags: RuntimeFeatureFlags
   isDesktop?: boolean
   scrollHeader?: ReactNode
+  singlePayerOnly?: boolean
 }) {
   const t = useTranslations('ExpenseForm')
   const tDocuments = useTranslations('ExpenseDocumentsInput')
@@ -522,14 +532,15 @@ export function ExpenseForm({
   const collapsibleFieldsGridClass =
     'grid w-full min-w-0 grid-cols-1 items-start gap-4 sm:grid-cols-2 sm:gap-6'
 
-  const getDefaultPaidBy = (): string | undefined => {
+  const getDefaultPaidBy = (): ExpenseFormValues['paidBy'] | undefined => {
     if (!isCreate) return undefined
 
     if (
       currentUserId &&
       group.participants.some(({ id }) => id === currentUserId)
     ) {
-      return currentUserId
+      const initialAmount = Number(searchParams.get('amount')) || 0
+      return [{ participant: currentUserId, amount: initialAmount }]
     }
 
     return undefined
@@ -561,7 +572,18 @@ export function ExpenseForm({
               : undefined,
           conversionRate: expense.conversionRate?.toNumber(),
           category: expense.categoryId,
-          paidBy: expense.paidById,
+          paidBy:
+            expense.payers && expense.payers.length > 0
+              ? expense.payers.map((p) => ({
+                  participant: p.userId,
+                  amount: amountAsDecimal(p.amount, groupCurrency),
+                }))
+              : [
+                  {
+                    participant: expense.paidById,
+                    amount: amountAsDecimal(expense.amount, groupCurrency),
+                  },
+                ],
           paidFor: expense.paidFor.map(({ userId, shares }) => {
             const shareValue =
               expense.splitMode === 'BY_AMOUNT'
@@ -592,7 +614,17 @@ export function ExpenseForm({
             originalAmount: undefined,
             conversionRate: undefined,
             category: 1, // category with id 1 is Payment
-            paidBy: searchParams.get('from') ?? undefined,
+            paidBy: searchParams.get('from')
+              ? [
+                  {
+                    participant: searchParams.get('from')!,
+                    amount: amountAsDecimal(
+                      Number(searchParams.get('amount')) || 0,
+                      groupCurrency,
+                    ),
+                  },
+                ]
+              : getDefaultPaidBy(),
             paidFor: searchParams.get('to')
               ? [
                   {
@@ -624,7 +656,16 @@ export function ExpenseForm({
               category:
                 createPrefill.category ??
                 (createPrefill.isReimbursement ? 1 : 0),
-              paidBy: createPrefill.paidBy ?? getDefaultPaidBy(),
+              paidBy: createPrefill.paidBy
+                ? Array.isArray(createPrefill.paidBy)
+                  ? createPrefill.paidBy
+                  : [
+                      {
+                        participant: createPrefill.paidBy,
+                        amount: createPrefill.amount ?? 0,
+                      },
+                    ]
+                : getDefaultPaidBy(),
               paidFor: createPrefill.paidFor ?? defaultSplittingOptions.paidFor,
               isReimbursement: createPrefill.isReimbursement ?? false,
               splitMode:
@@ -784,6 +825,10 @@ export function ExpenseForm({
 
     // Store monetary amounts in minor units (cents)
     values.amount = amountAsMinorUnits(values.amount, groupCurrency)
+    values.paidBy = values.paidBy.map(({ participant, amount }) => ({
+      participant,
+      amount: amountAsMinorUnits(amount, groupCurrency),
+    }))
     values.paidFor = values.paidFor.map(({ participant, shares }) => ({
       participant,
       shares:
@@ -895,6 +940,36 @@ export function ExpenseForm({
   useEffect(() => {
     setManuallyEditedParticipants(new Set())
   }, [splitMode, amount])
+
+  // When isReimbursement is toggled on and there are multiple payers, collapse to single payer
+  const isReimbursement = form.watch('isReimbursement')
+  useEffect(() => {
+    if (!isReimbursement) return
+    const currentPaidBy = form.getValues('paidBy')
+    if (Array.isArray(currentPaidBy) && currentPaidBy.length > 1) {
+      form.setValue('paidBy', [currentPaidBy[0]], {
+        shouldDirty: true,
+        shouldValidate: true,
+      })
+    }
+  }, [isReimbursement, form])
+
+  // Synchronize single-payer amount with the expense total.
+  // When there's only one payer, their amount must always equal the expense amount.
+  const paidBy = form.watch('paidBy')
+  useEffect(() => {
+    if (!Array.isArray(paidBy) || paidBy.length !== 1) return
+    const expenseAmount = Number(amount) || 0
+    const currentPayerAmount =
+      typeof paidBy[0].amount === 'string'
+        ? Number(paidBy[0].amount) || 0
+        : paidBy[0].amount
+    if (currentPayerAmount !== expenseAmount) {
+      form.setValue('paidBy', [{ ...paidBy[0], amount: expenseAmount }], {
+        shouldValidate: false,
+      })
+    }
+  }, [amount, paidBy, form])
 
   useEffect(() => {
     const splitMode = form.getValues().splitMode
@@ -1254,45 +1329,6 @@ export function ExpenseForm({
                     )}
                   />
 
-                  <FormField
-                    control={form.control}
-                    name="paidBy"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>
-                          {t(`${sExpense}.paidByField.label`)}
-                        </FormLabel>
-                        <Select
-                          items={group.participants.map(({ id, name }) => ({
-                            value: id,
-                            label: name,
-                          }))}
-                          onValueChange={field.onChange}
-                          value={field.value ?? getDefaultPaidBy()}
-                        >
-                          <SelectTrigger className="w-full">
-                            <SelectValue
-                              placeholder={t(
-                                `${sExpense}.paidByField.placeholder`,
-                              )}
-                            />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {group.participants.map(({ id, name }) => (
-                              <SelectItem key={id} value={id}>
-                                {name}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormDescription>
-                          {t(`${sExpense}.paidByField.description`)}
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
                   {conversionRequired ? (
                     <FormField
                       control={form.control}
@@ -1536,6 +1572,41 @@ export function ExpenseForm({
                   )}
                 </ExpenseFormSectionContent>
               </ExpenseFormSection>
+
+              <Card className="gap-4 py-0 shadow-none ring-0">
+                <CardHeader className="px-0">
+                  <CardTitle>{t(`${sExpense}.paidByField.label`)}</CardTitle>
+                  <CardDescription>
+                    {t(`${sExpense}.paidByField.description`)}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="px-0">
+                  <FormField
+                    control={form.control}
+                    name="paidBy"
+                    render={({ field }) => (
+                      <FormItem className="space-y-0">
+                        <PayerSelector
+                          participants={group.participants.map(
+                            ({ id, name }) => ({
+                              id,
+                              name: name?.trim() || id,
+                            }),
+                          )}
+                          value={(field.value ?? []) as PayerEntry[]}
+                          onChange={field.onChange}
+                          expenseTotal={Number(form.watch('amount')) || 0}
+                          currency={groupCurrency}
+                          locale={locale}
+                          isReimbursement={form.watch('isReimbursement')}
+                          singlePayerOnly={singlePayerOnly}
+                        />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </CardContent>
+              </Card>
 
               <ExpenseFormSection>
                 <ExpenseFormSectionHeader>

--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -43,6 +43,7 @@ export async function GET(
           conversionRate: true,
           paidById: true,
           paidFor: { select: { userId: true, shares: true } },
+          payers: { select: { userId: true, amount: true } },
           isReimbursement: true,
           splitMode: true,
         },
@@ -129,6 +130,7 @@ export async function GET(
     splitMode: splitModeLabel[expense.splitMode],
     ...Object.fromEntries(
       participants.map((participant) => {
+        // Compute beneficiary debit from paidFor shares
         const { totalShares, participantShare } = expense.paidFor.reduce(
           (acc, { userId, shares }) => {
             acc.totalShares += shares
@@ -140,19 +142,46 @@ export async function GET(
           { totalShares: 0, participantShare: 0 },
         )
 
-        const isPaidByParticipant = expense.paidById === participant.id
-        const participantAmountShare =
+        const isSinglePayer = expense.payers.length <= 1
+
+        if (isSinglePayer) {
+          // Single-payer: preserve backward-compatible format
+          // Payer column = +share, non-payer column = -share
+          const isPaidByParticipant =
+            (expense.payers.length === 1 &&
+              expense.payers[0].userId === participant.id) ||
+            (expense.payers.length === 0 && expense.paidById === participant.id)
+          const participantAmountShare =
+            totalShares === 0
+              ? 0
+              : +formatAmountAsDecimal(
+                  (expense.amount / totalShares) * participantShare,
+                  currency,
+                )
+
+          return [
+            participant.name,
+            participantAmountShare * (isPaidByParticipant ? 1 : -1),
+          ]
+        }
+
+        // Multi-payer: net position = payer credit - beneficiary debit
+        const debit =
           totalShares === 0
             ? 0
-            : +formatAmountAsDecimal(
-                (expense.amount / totalShares) * participantShare,
-                currency,
-              )
+            : (expense.amount / totalShares) * participantShare
 
-        return [
-          participant.name,
-          participantAmountShare * (isPaidByParticipant ? 1 : -1),
-        ]
+        // Compute payer credit from payers array
+        const payerEntry = expense.payers.find(
+          (p) => p.userId === participant.id,
+        )
+        const credit = payerEntry ? payerEntry.amount : 0
+
+        // Net amount: payer credit (positive) minus beneficiary debit (negative)
+        const net = credit - debit
+        const netFormatted = +formatAmountAsDecimal(net, currency)
+
+        return [participant.name, netFormatted]
       }),
     ),
   }))

--- a/src/app/groups/[groupId]/expenses/export/json/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/json/route.ts
@@ -25,6 +25,7 @@ export async function GET(
           originalCurrency: true,
           conversionRate: true,
           paidById: true,
+          payers: { select: { userId: true, amount: true } },
           paidFor: { select: { userId: true, shares: true } },
           isReimbursement: true,
           splitMode: true,
@@ -41,8 +42,23 @@ export async function GET(
     return NextResponse.json({ error: 'Invalid group ID' }, { status: 404 })
 
   // Map to backward-compatible export shape
+  const expenses = group.expenses.map((expense) => {
+    const paidBy =
+      expense.payers.length > 0
+        ? expense.payers.map((p) => ({ userId: p.userId, amount: p.amount }))
+        : [{ userId: expense.paidById, amount: expense.amount }]
+
+    const { payers, ...rest } = expense
+    return {
+      ...rest,
+      paidById: paidBy[0].userId,
+      paidBy,
+    }
+  })
+
   const exportData = {
     ...group,
+    expenses,
     participants: group.memberships.map((m) => ({
       id: m.user.id,
       name: m.user.name,

--- a/src/app/groups/[groupId]/expenses/payment-form.tsx
+++ b/src/app/groups/[groupId]/expenses/payment-form.tsx
@@ -138,7 +138,9 @@ export function PaymentForm({
   const groupCurrency = getCurrencyFromGroup(group)
   const defaultPaidBy =
     expense?.paidById ??
-    createPrefill?.paidBy ??
+    (typeof createPrefill?.paidBy === 'string'
+      ? createPrefill.paidBy
+      : createPrefill?.paidBy?.[0]?.participant) ??
     getDefaultPaidBy(group, currentUserId)
 
   const { checkForDuplicates, isChecking } = useDuplicateCheck({
@@ -205,7 +207,7 @@ export function PaymentForm({
       title: '',
       category: PAYMENT_CATEGORY_ID,
       amount: amountMinor,
-      paidBy: values.paidBy,
+      paidBy: [{ participant: values.paidBy, amount: amountMinor }],
       paidFor: [{ participant: values.paidTo, shares: amountMinor }],
       splitMode: 'BY_AMOUNT',
       saveDefaultSplittingOptions: false,

--- a/src/components/category-selector.tsx
+++ b/src/components/category-selector.tsx
@@ -98,7 +98,6 @@ export function CategorySelector({
   // allow overwriting currently selected category from outside
   useEffect(() => {
     setValue(defaultValue)
-    onValueChange(defaultValue)
   }, [defaultValue])
 
   if (!isClient || !isDesktop) {

--- a/src/components/expense-detail/expense-detail.tsx
+++ b/src/components/expense-detail/expense-detail.tsx
@@ -382,6 +382,11 @@ export type ExpenseDetailContentProps = {
     notes: string | null
     category: Category | null
     paidBy: { id: string; name: string | null; email?: string | null }
+    payers?: Array<{
+      userId: string
+      amount: number
+      user: { id: string; name: string | null }
+    }>
     paidFor: Array<{
       userId: string
       shares: number
@@ -699,17 +704,48 @@ export function ExpenseDetailContent({
       {!expense.isReimbursement ? (
         <Card>
           <CardContent className="flex flex-col gap-4 pt-6">
-            <div className="flex items-center gap-3">
-              <ParticipantAvatar name={expense.paidBy.name} size="lg" />
-              <p className="text-base">
-                {profileId === expense.paidBy.id
-                  ? t('youPaidAmount', { amount: formattedAmount })
-                  : t('paidAmount', {
-                      name: expense.paidBy.name ?? t('someone'),
-                      amount: formattedAmount,
-                    })}
-              </p>
-            </div>
+            {expense.payers && expense.payers.length > 1 ? (
+              <div className="flex flex-col gap-3">
+                {expense.payers.map((payer, index) => {
+                  const payerAmount = formatCurrency(
+                    currency,
+                    payer.amount,
+                    locale,
+                  )
+                  const isCurrentUser = profileId === payer.userId
+                  return (
+                    <div key={payer.userId} className="flex items-center gap-3">
+                      <ParticipantAvatar
+                        name={payer.user.name}
+                        size={index === 0 ? 'lg' : 'md'}
+                      />
+                      <p className={index === 0 ? 'text-base' : 'text-sm'}>
+                        {isCurrentUser
+                          ? t('youPaidAmountMultiple', {
+                              amount: payerAmount,
+                            })
+                          : t('paidAmountMultiple', {
+                              name: payer.user.name ?? t('someone'),
+                              amount: payerAmount,
+                            })}
+                      </p>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <div className="flex items-center gap-3">
+                <ParticipantAvatar name={expense.paidBy.name} size="lg" />
+                <p className="text-base">
+                  {profileId === expense.paidBy.id
+                    ? t('youPaidAmount', { amount: formattedAmount })
+                    : t('paidAmount', {
+                        name: expense.paidBy.name ?? t('someone'),
+                        amount: formattedAmount,
+                      })}
+                </p>
+              </div>
+            )}
 
             {splitLines.length > 0 ? (
               <>

--- a/src/components/floating-create-expense.tsx
+++ b/src/components/floating-create-expense.tsx
@@ -292,7 +292,7 @@ export function FloatingCreateExpense({
     groupParticipants.forEach((p) => {
       uniqueMap.set(p.id, {
         id: p.id,
-        name: p.name ?? '',
+        name: p.name?.trim() || p.id,
         email: p.email ?? null,
       })
     })
@@ -529,7 +529,7 @@ export function FloatingCreateExpense({
               title: values.title,
               amount: amountMajor,
               currency: activeCurrency,
-              paidById: values.paidBy,
+              paidById: values.paidBy[0].participant,
               expenseDate: values.expenseDate,
               notes: values.notes || undefined,
               groupId: selectedGroup.id,
@@ -571,7 +571,7 @@ export function FloatingCreateExpense({
             amount: values.amount,
             currency:
               values.originalCurrency || profile?.preferredCurrency || 'EUR',
-            fromUserId: values.paidBy,
+            fromUserId: values.paidBy[0].participant,
             toUserId: values.paidFor[0].participant,
             date: values.expenseDate,
           })
@@ -584,7 +584,7 @@ export function FloatingCreateExpense({
             amount: values.amount,
             currency:
               values.originalCurrency || profile?.preferredCurrency || 'EUR',
-            paidById: values.paidBy,
+            paidById: values.paidBy[0].participant,
             expenseDate: values.expenseDate,
             notes: values.notes || undefined,
             recurrenceRule: values.recurrenceRule,
@@ -601,7 +601,7 @@ export function FloatingCreateExpense({
             title: values.title,
             amount: amountMajor,
             currency: activeCurrency,
-            paidById: values.paidBy,
+            paidById: values.paidBy[0].participant,
             expenseDate: values.expenseDate,
             notes: values.notes || undefined,
             groupId: null,
@@ -744,6 +744,8 @@ export function FloatingCreateExpense({
             runtimeFeatureFlags={runtimeFeatureFlags}
             isDesktop={isDesktop}
             scrollHeader={participantScrollHeader}
+            // Friend and hybrid (group+friends) paths only persist the first payer
+            singlePayerOnly={selectedFriends.length > 0}
           />
         )
       ) : !editingExpenseId ? (

--- a/src/components/payer-selector.tsx
+++ b/src/components/payer-selector.tsx
@@ -1,0 +1,516 @@
+'use client'
+
+import { CurrencyAmountInput } from '@/components/currency-amount-input'
+import { Badge } from '@/components/ui/badge'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+  FieldTitle,
+} from '@/components/ui/field'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+} from '@/components/ui/input-group'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Locale } from '@/i18n'
+import type { Currency } from '@/lib/currency'
+import { getCurrencyDisplaySymbol } from '@/lib/currency-input'
+import {
+  distributeEqualAmounts,
+  distributeWeightedAmounts,
+} from '@/lib/distribute-amount'
+import { formatCurrency } from '@/lib/utils'
+import { useTranslations } from 'next-intl'
+import { useEffect, useId, useState } from 'react'
+
+export interface PayerEntry {
+  participant: string
+  amount: number | string
+}
+
+export type PayerMode =
+  | 'single'
+  | 'evenly'
+  | 'by_shares'
+  | 'by_percentage'
+  | 'by_amount'
+
+export interface PayerSelectorProps {
+  participants: Array<{ id: string; name: string }>
+  value: PayerEntry[]
+  onChange: (payers: PayerEntry[]) => void
+  expenseTotal: number
+  currency: Currency
+  locale: Locale
+  disabled?: boolean
+  isReimbursement?: boolean
+  /** When true, prevents multiple payers (friend/hybrid flows). */
+  singlePayerOnly?: boolean
+}
+
+function entryAmount(entry: PayerEntry): number {
+  return typeof entry.amount === 'string'
+    ? Number(entry.amount) || 0
+    : entry.amount
+}
+
+function inferMode(value: PayerEntry[], forceSingle: boolean): PayerMode {
+  if (forceSingle || value.length <= 1) return 'single'
+  return 'by_amount'
+}
+
+export function PayerSelector({
+  participants,
+  value,
+  onChange,
+  expenseTotal,
+  currency,
+  locale,
+  disabled = false,
+  isReimbursement = false,
+  singlePayerOnly = false,
+}: PayerSelectorProps) {
+  const t = useTranslations('Expenses')
+  const idPrefix = useId()
+  const forceSingle = singlePayerOnly || isReimbursement
+  const decimalDigits = currency.decimal_digits
+
+  const [mode, setMode] = useState<PayerMode>(() =>
+    inferMode(value, forceSingle),
+  )
+  const [shares, setShares] = useState<Record<string, number>>(() =>
+    Object.fromEntries(value.map((e) => [e.participant, 1])),
+  )
+  const [percentages, setPercentages] = useState<Record<string, number>>(() => {
+    if (value.length === 0 || expenseTotal <= 0) {
+      return Object.fromEntries(value.map((e) => [e.participant, 0]))
+    }
+    return Object.fromEntries(
+      value.map((e) => [
+        e.participant,
+        Math.round((entryAmount(e) / expenseTotal) * 10000) / 100,
+      ]),
+    )
+  })
+
+  useEffect(() => {
+    if (forceSingle && mode !== 'single') {
+      setMode('single')
+      const participant = value[0]?.participant ?? participants[0]?.id ?? ''
+      if (participant) {
+        onChange([{ participant, amount: expenseTotal }])
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only react to forceSingle
+  }, [forceSingle])
+
+  const selectedIds = value.map((e) => e.participant)
+  const selectedSet = new Set(selectedIds)
+
+  const runningTotal = value.reduce((sum, entry) => sum + entryAmount(entry), 0)
+  const hasMismatch =
+    Math.round(runningTotal * 10 ** decimalDigits) !==
+    Math.round(expenseTotal * 10 ** decimalDigits)
+
+  const emitEvenly = (ids: string[]) => {
+    if (ids.length === 0) {
+      onChange([])
+      return
+    }
+    const amounts = distributeEqualAmounts(
+      expenseTotal,
+      ids.length,
+      decimalDigits,
+    )
+    onChange(ids.map((id, i) => ({ participant: id, amount: amounts[i] ?? 0 })))
+  }
+
+  const emitFromShares = (
+    ids: string[],
+    nextShares: Record<string, number>,
+  ) => {
+    if (ids.length === 0) {
+      onChange([])
+      return
+    }
+    const weights = ids.map((id) => nextShares[id] ?? 1)
+    const amounts = distributeWeightedAmounts(
+      expenseTotal,
+      weights,
+      decimalDigits,
+    )
+    onChange(ids.map((id, i) => ({ participant: id, amount: amounts[i] ?? 0 })))
+  }
+
+  const emitFromPercentages = (
+    ids: string[],
+    nextPct: Record<string, number>,
+  ) => {
+    if (ids.length === 0) {
+      onChange([])
+      return
+    }
+    const weights = ids.map((id) => nextPct[id] ?? 0)
+    const amounts = distributeWeightedAmounts(
+      expenseTotal,
+      weights,
+      decimalDigits,
+    )
+    onChange(ids.map((id, i) => ({ participant: id, amount: amounts[i] ?? 0 })))
+  }
+
+  const handleModeChange = (next: string | null) => {
+    if (!next) return
+    const nextMode = next as PayerMode
+    if (forceSingle && nextMode !== 'single') return
+    setMode(nextMode)
+
+    if (nextMode === 'single') {
+      const participant = value[0]?.participant ?? participants[0]?.id ?? ''
+      if (participant) {
+        onChange([{ participant, amount: expenseTotal }])
+      }
+      return
+    }
+
+    const ids =
+      selectedIds.length > 0
+        ? selectedIds
+        : participants
+            .slice(0, Math.min(2, participants.length))
+            .map((p) => p.id)
+
+    if (nextMode === 'evenly') {
+      emitEvenly(ids)
+    } else if (nextMode === 'by_shares') {
+      const nextShares = { ...shares }
+      for (const id of ids) {
+        if (nextShares[id] == null) nextShares[id] = 1
+      }
+      setShares(nextShares)
+      emitFromShares(ids, nextShares)
+    } else if (nextMode === 'by_percentage') {
+      const equal = ids.length > 0 ? Math.floor(10000 / ids.length) / 100 : 0
+      const nextPct: Record<string, number> = {}
+      let used = 0
+      ids.forEach((id, i) => {
+        const pct =
+          i === ids.length - 1 ? Math.round((100 - used) * 100) / 100 : equal
+        nextPct[id] = pct
+        used += pct
+      })
+      setPercentages(nextPct)
+      emitFromPercentages(ids, nextPct)
+    } else {
+      // by_amount — keep current amounts or seed evenly
+      if (value.length <= 1) {
+        emitEvenly(ids)
+      }
+    }
+  }
+
+  const handleSingleParticipant = (participantId: string) => {
+    onChange([{ participant: participantId, amount: expenseTotal }])
+  }
+
+  const toggleParticipant = (participantId: string, checked: boolean) => {
+    let ids = checked
+      ? [...selectedIds, participantId]
+      : selectedIds.filter((id) => id !== participantId)
+
+    if (ids.length === 0 && participants[0]) {
+      ids = [participants[0].id]
+    }
+
+    if (mode === 'evenly') {
+      emitEvenly(ids)
+    } else if (mode === 'by_shares') {
+      const nextShares = { ...shares }
+      if (checked && nextShares[participantId] == null) {
+        nextShares[participantId] = 1
+      }
+      setShares(nextShares)
+      emitFromShares(ids, nextShares)
+    } else if (mode === 'by_percentage') {
+      const nextPct = { ...percentages }
+      if (checked && nextPct[participantId] == null) {
+        nextPct[participantId] = 0
+      }
+      setPercentages(nextPct)
+      emitFromPercentages(ids, nextPct)
+    } else {
+      // by_amount
+      if (checked) {
+        onChange([...value, { participant: participantId, amount: 0 }])
+      } else {
+        onChange(value.filter((e) => e.participant !== participantId))
+      }
+    }
+  }
+
+  const handleShareChange = (participantId: string, raw: string) => {
+    const n = Number(raw)
+    const nextShares = {
+      ...shares,
+      [participantId]: Number.isNaN(n) || n < 0 ? 0 : n,
+    }
+    setShares(nextShares)
+    emitFromShares(selectedIds, nextShares)
+  }
+
+  const handlePercentageChange = (participantId: string, raw: string) => {
+    const n = Number(raw)
+    const nextPct = {
+      ...percentages,
+      [participantId]: Number.isNaN(n) || n < 0 ? 0 : n,
+    }
+    setPercentages(nextPct)
+    emitFromPercentages(selectedIds, nextPct)
+  }
+
+  const handleAmountChange = (participantId: string, newAmount: string) => {
+    const numericAmount = Number(newAmount)
+    onChange(
+      value.map((entry) =>
+        entry.participant === participantId
+          ? {
+              ...entry,
+              amount: Number.isNaN(numericAmount) ? newAmount : numericAmount,
+            }
+          : entry,
+      ),
+    )
+  }
+
+  // Keep evenly / shares / % in sync when expense total changes
+  useEffect(() => {
+    if (mode === 'evenly' && selectedIds.length > 0) {
+      emitEvenly(selectedIds)
+    } else if (mode === 'by_shares' && selectedIds.length > 0) {
+      emitFromShares(selectedIds, shares)
+    } else if (mode === 'by_percentage' && selectedIds.length > 0) {
+      emitFromPercentages(selectedIds, percentages)
+    } else if (mode === 'single' && value[0]) {
+      const current = entryAmount(value[0])
+      if (current !== expenseTotal) {
+        onChange([{ ...value[0], amount: expenseTotal }])
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expenseTotal])
+
+  const formatMajorAsCurrency = (major: number) =>
+    formatCurrency(currency, Math.round(major * 10 ** decimalDigits), locale)
+
+  const multipleModes: Array<{
+    mode: Exclude<PayerMode, 'single'>
+    title: string
+    description: string
+  }> = [
+    {
+      mode: 'evenly',
+      title: t('paidBy.evenlyTitle'),
+      description: t('paidBy.evenlyDescription'),
+    },
+    {
+      mode: 'by_shares',
+      title: t('paidBy.bySharesTitle'),
+      description: t('paidBy.bySharesDescription'),
+    },
+    {
+      mode: 'by_percentage',
+      title: t('paidBy.byPercentageTitle'),
+      description: t('paidBy.byPercentageDescription'),
+    },
+    {
+      mode: 'by_amount',
+      title: t('paidBy.byAmountTitle'),
+      description: t('paidBy.byAmountDescription'),
+    },
+  ]
+
+  const renderParticipantControls = () => (
+    <div className="flex flex-col gap-2 pt-2">
+      <p className="text-xs text-muted-foreground">
+        {t('paidBy.selectPayers')}
+      </p>
+      {participants.map((p) => {
+        const checked = selectedSet.has(p.id)
+        const amountEntry = value.find((e) => e.participant === p.id)
+        return (
+          <div key={p.id} className="flex items-center gap-2">
+            <Checkbox
+              checked={checked}
+              disabled={disabled}
+              onCheckedChange={(state) =>
+                toggleParticipant(p.id, state === true)
+              }
+              aria-label={p.name}
+            />
+            <span className="min-w-0 flex-1 truncate text-sm">{p.name}</span>
+            {checked && mode === 'by_shares' && (
+              <InputGroup className="w-24 shrink-0">
+                <InputGroupInput
+                  type="number"
+                  min={0}
+                  step={1}
+                  disabled={disabled}
+                  value={shares[p.id] ?? 1}
+                  onChange={(e) => handleShareChange(p.id, e.target.value)}
+                  aria-label={t('paidBy.shareLabel')}
+                />
+              </InputGroup>
+            )}
+            {checked && mode === 'by_percentage' && (
+              <InputGroup className="w-28 shrink-0">
+                <InputGroupInput
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={0.01}
+                  disabled={disabled}
+                  value={percentages[p.id] ?? 0}
+                  onChange={(e) => handlePercentageChange(p.id, e.target.value)}
+                  aria-label={t('paidBy.percentageLabel')}
+                />
+                <InputGroupAddon align="inline-end">
+                  <InputGroupText>%</InputGroupText>
+                </InputGroupAddon>
+              </InputGroup>
+            )}
+            {checked && mode === 'by_amount' && (
+              <InputGroup className="min-w-0 w-36 shrink-0">
+                <InputGroupAddon align="inline-start">
+                  <InputGroupText className="font-medium text-foreground tabular-nums">
+                    {getCurrencyDisplaySymbol(currency)}
+                  </InputGroupText>
+                </InputGroupAddon>
+                <CurrencyAmountInput
+                  disabled={disabled}
+                  currency={currency}
+                  locale={locale}
+                  value={amountEntry ? entryAmount(amountEntry) : 0}
+                  onValueChange={(val) => handleAmountChange(p.id, val)}
+                />
+              </InputGroup>
+            )}
+            {checked && mode === 'evenly' && amountEntry && (
+              <span className="text-sm tabular-nums text-muted-foreground">
+                {formatMajorAsCurrency(entryAmount(amountEntry))}
+              </span>
+            )}
+          </div>
+        )
+      })}
+
+      {mode === 'by_amount' && (
+        <div className="flex flex-wrap items-center gap-2 pt-1 text-sm">
+          <span className="text-muted-foreground">
+            {t('paidBy.total')}: {formatMajorAsCurrency(runningTotal)}
+          </span>
+          {hasMismatch && (
+            <Badge variant="destructive">
+              {runningTotal > expenseTotal
+                ? t('paidBy.overpayment', {
+                    amount: formatMajorAsCurrency(runningTotal - expenseTotal),
+                  })
+                : t('paidBy.underpayment', {
+                    amount: formatMajorAsCurrency(expenseTotal - runningTotal),
+                  })}
+            </Badge>
+          )}
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <RadioGroup
+      value={mode}
+      onValueChange={handleModeChange}
+      disabled={disabled}
+      className="flex flex-col gap-3"
+    >
+      <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+        {t('paidBy.singleSection')}
+      </p>
+      <FieldLabel htmlFor={`${idPrefix}-single`}>
+        <Field orientation="horizontal">
+          <FieldContent>
+            <FieldTitle>{t('paidBy.singleTitle')}</FieldTitle>
+            <FieldDescription>{t('paidBy.singleDescription')}</FieldDescription>
+            {mode === 'single' && (
+              <div className="pt-2" onClick={(e) => e.stopPropagation()}>
+                <Select
+                  value={value[0]?.participant ?? ''}
+                  items={participants.map((p) => ({
+                    value: p.id,
+                    label: p.name.trim() || p.id,
+                  }))}
+                  onValueChange={(val) => handleSingleParticipant(val ?? '')}
+                  disabled={disabled}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {participants.map((p) => (
+                      <SelectItem key={p.id} value={p.id}>
+                        {p.name.trim() || p.id}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </FieldContent>
+          <RadioGroupItem
+            value="single"
+            id={`${idPrefix}-single`}
+            disabled={disabled}
+          />
+        </Field>
+      </FieldLabel>
+
+      {!forceSingle && (
+        <>
+          <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+            {t('paidBy.multipleSection')}
+          </p>
+          {multipleModes.map(({ mode: m, title, description }) => (
+            <FieldLabel key={m} htmlFor={`${idPrefix}-${m}`}>
+              <Field orientation="horizontal">
+                <FieldContent>
+                  <FieldTitle>{title}</FieldTitle>
+                  <FieldDescription>{description}</FieldDescription>
+                  {mode === m && (
+                    <div onClick={(e) => e.stopPropagation()}>
+                      {renderParticipantControls()}
+                    </div>
+                  )}
+                </FieldContent>
+                <RadioGroupItem
+                  value={m}
+                  id={`${idPrefix}-${m}`}
+                  disabled={disabled}
+                />
+              </Field>
+            </FieldLabel>
+          ))}
+        </>
+      )}
+    </RadioGroup>
+  )
+}

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,0 +1,238 @@
+'use client'
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import { useMemo } from 'react'
+
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
+
+function FieldSet({ className, ...props }: React.ComponentProps<'fieldset'>) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        'flex flex-col gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLegend({
+  className,
+  variant = 'legend',
+  ...props
+}: React.ComponentProps<'legend'> & { variant?: 'legend' | 'label' }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        'mb-3 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        'group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+const fieldVariants = cva(
+  'group/field flex w-full gap-3 data-[invalid=true]:text-destructive',
+  {
+    variants: {
+      orientation: {
+        vertical: 'flex-col *:w-full [&>.sr-only]:w-auto',
+        horizontal:
+          'flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
+        responsive:
+          'flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
+      },
+    },
+    defaultVariants: {
+      orientation: 'vertical',
+    },
+  },
+)
+
+function Field({
+  className,
+  orientation = 'vertical',
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        'group/field-content flex flex-1 flex-col gap-1 leading-snug',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        'group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border *:data-[slot=field]:p-3 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10',
+        'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        'flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        'text-start text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5',
+        'last:mt-0 nth-last-2:-mt-1',
+        '[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<'div'> & {
+  children?: React.ReactNode
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        'relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2',
+        className,
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<'div'> & {
+  errors?: Array<{ message?: string } | undefined>
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = Array.from(
+      new Map(errors.map((error) => [error?.message, error])).values(),
+    )
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ms-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>,
+        )}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn('text-sm font-normal text-destructive', className)}
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
+export {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
+}

--- a/src/lib/__tests__/activity-diff-idempotent.property.test.ts
+++ b/src/lib/__tests__/activity-diff-idempotent.property.test.ts
@@ -28,13 +28,20 @@ function toFormValues(expense: {
   notes?: string | null
   recurrenceRule?: string | null
   paidFor: Array<{ userId: string }>
+  payers?: Array<{ userId: string; amount: number }>
 }) {
   return {
     title: expense.title,
     amount: expense.amount,
     expenseDate: expense.expenseDate,
     category: expense.categoryId,
-    paidBy: expense.paidById,
+    paidBy:
+      expense.payers && expense.payers.length > 0
+        ? expense.payers.map((p) => ({
+            participant: p.userId,
+            amount: p.amount,
+          }))
+        : [{ participant: expense.paidById, amount: expense.amount }],
     splitMode: expense.splitMode,
     isReimbursement: expense.isReimbursement,
     notes: expense.notes ?? null,

--- a/src/lib/__tests__/activity-diff-multi-payer.property.test.ts
+++ b/src/lib/__tests__/activity-diff-multi-payer.property.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Property-based tests for multi-payer activity diff — payer change detection.
+ *
+ * Feature: multi-payer-expenses
+ * - Property 5: Activity Diff Payer Change Detection
+ *
+ * Validates: Requirements 5.1, 5.2, 5.4
+ */
+
+import fc from 'fast-check'
+import { computeExpenseChanges, serializePayers } from '../activity-diff'
+
+// --- Generators ---
+
+const arbUserId = fc.uuid()
+
+/**
+ * Generates a payer entry: { userId, amount } with positive integer amount.
+ */
+const arbPayerEntry = fc.record({
+  userId: arbUserId,
+  amount: fc.integer({ min: 1, max: 1_000_000 }),
+})
+
+/**
+ * Generates a payer state: an array of 1–5 unique-userId payer entries.
+ * Ensures no duplicate userIds (since ExpensePaidBy has composite key).
+ */
+const arbPayerState = fc
+  .array(arbPayerEntry, { minLength: 1, maxLength: 5 })
+  .map((entries) => {
+    // Deduplicate by userId, keeping first occurrence
+    const seen = new Set<string>()
+    return entries.filter((e) => {
+      if (seen.has(e.userId)) return false
+      seen.add(e.userId)
+      return true
+    })
+  })
+  .filter((entries) => entries.length >= 1)
+
+/**
+ * Builds a minimal "existing" expense object suitable for computeExpenseChanges.
+ * Non-payer fields are fixed so they don't generate noise changes.
+ */
+function buildExistingExpense(
+  payers: Array<{ userId: string; amount: number }>,
+) {
+  const total = payers.reduce((sum, p) => sum + p.amount, 0)
+  return {
+    title: 'Test Expense',
+    amount: total,
+    expenseDate: new Date('2024-01-15T00:00:00.000Z'),
+    categoryId: 1,
+    paidById: payers[0].userId,
+    splitMode: 'EVENLY',
+    isReimbursement: false,
+    notes: null,
+    recurrenceRule: null,
+    paidFor: payers.map((p) => ({ userId: p.userId })),
+    payers,
+  }
+}
+
+/**
+ * Builds a minimal "updated" form values object suitable for computeExpenseChanges.
+ * Non-payer fields match the existing expense so only payer changes are detected.
+ */
+function buildUpdatedFormValues(
+  payers: Array<{ userId: string; amount: number }>,
+) {
+  const total = payers.reduce((sum, p) => sum + p.amount, 0)
+  return {
+    title: 'Test Expense',
+    amount: total,
+    expenseDate: new Date('2024-01-15T00:00:00.000Z'),
+    category: 1,
+    paidBy: payers.map((p) => ({ participant: p.userId, amount: p.amount })),
+    splitMode: 'EVENLY',
+    isReimbursement: false,
+    notes: null,
+    recurrenceRule: null,
+    paidFor: payers.map((p) => ({ participant: p.userId })),
+  }
+}
+
+/**
+ * Compares two payer states as sets of (userId, amount) pairs.
+ * Order-independent — only the content matters.
+ */
+function payerSetsEqual(
+  a: Array<{ userId: string; amount: number }>,
+  b: Array<{ userId: string; amount: number }>,
+): boolean {
+  const sortedA = [...a].sort((x, y) => x.userId.localeCompare(y.userId))
+  const sortedB = [...b].sort((x, y) => x.userId.localeCompare(y.userId))
+  if (sortedA.length !== sortedB.length) return false
+  return sortedA.every(
+    (entry, i) =>
+      entry.userId === sortedB[i].userId && entry.amount === sortedB[i].amount,
+  )
+}
+
+// --- Constants ---
+
+const PBT_NUM_RUNS = 100
+
+// --- Tests ---
+
+describe('Activity Diff — Multi-Payer Change Detection Property Tests', () => {
+  describe('Property 5: Activity Diff Payer Change Detection', () => {
+    /**
+     * Validates: Requirements 5.1, 5.2, 5.4
+     *
+     * For any two payer states (old and new), the activity diff SHALL record a
+     * `paidBy` field change if and only if the sets of (userId, amount) pairs differ.
+     */
+    it('records a paidBy change if and only if (userId, amount) sets differ', () => {
+      fc.assert(
+        fc.property(arbPayerState, arbPayerState, (oldPayers, newPayers) => {
+          const existing = buildExistingExpense(oldPayers)
+          const updated = buildUpdatedFormValues(newPayers)
+
+          // Align non-payer fields that depend on payer total to avoid noise
+          // We need to make amount/paidFor consistent so only paidBy change is tested
+          existing.amount = oldPayers.reduce((s, p) => s + p.amount, 0)
+          updated.amount = newPayers.reduce((s, p) => s + p.amount, 0)
+
+          const changes = computeExpenseChanges(existing, updated)
+          const paidByChange = changes.find((c) => c.field === 'paidBy')
+
+          const setsAreDifferent = !payerSetsEqual(oldPayers, newPayers)
+
+          if (setsAreDifferent) {
+            expect(paidByChange).toBeDefined()
+          } else {
+            expect(paidByChange).toBeUndefined()
+          }
+        }),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    /**
+     * Validates: Requirements 5.1, 5.2, 5.4
+     *
+     * When a paidBy change IS recorded, the serialized old and new values
+     * SHALL be parseable JSON arrays of {userId, amount} objects that
+     * round-trip back to the original payer states.
+     */
+    it('serialized paidBy values round-trip back to original payer states', () => {
+      fc.assert(
+        fc.property(arbPayerState, arbPayerState, (oldPayers, newPayers) => {
+          // Only test round-trip when sets actually differ
+          if (payerSetsEqual(oldPayers, newPayers)) return
+
+          const existing = buildExistingExpense(oldPayers)
+          const updated = buildUpdatedFormValues(newPayers)
+
+          existing.amount = oldPayers.reduce((s, p) => s + p.amount, 0)
+          updated.amount = newPayers.reduce((s, p) => s + p.amount, 0)
+
+          const changes = computeExpenseChanges(existing, updated)
+          const paidByChange = changes.find((c) => c.field === 'paidBy')
+
+          expect(paidByChange).toBeDefined()
+          expect(paidByChange!.oldValue).not.toBeNull()
+          expect(paidByChange!.newValue).not.toBeNull()
+
+          // Parse the serialized values back
+          const parsedOld = JSON.parse(paidByChange!.oldValue!) as Array<{
+            userId: string
+            amount: number
+          }>
+          const parsedNew = JSON.parse(paidByChange!.newValue!) as Array<{
+            userId: string
+            amount: number
+          }>
+
+          // Verify round-trip: parsed values should match original payer states (order-independent)
+          expect(payerSetsEqual(parsedOld, oldPayers)).toBe(true)
+          expect(payerSetsEqual(parsedNew, newPayers)).toBe(true)
+        }),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    /**
+     * Validates: Requirements 5.4
+     *
+     * When a single-payer expense remains single-payer with the same user and amount,
+     * no paidBy change is recorded (identity case).
+     */
+    it('identical payer state produces no paidBy change', () => {
+      fc.assert(
+        fc.property(arbPayerState, (payers) => {
+          const existing = buildExistingExpense(payers)
+          const updated = buildUpdatedFormValues(payers)
+
+          // Ensure consistent amounts
+          existing.amount = payers.reduce((s, p) => s + p.amount, 0)
+          updated.amount = payers.reduce((s, p) => s + p.amount, 0)
+
+          const changes = computeExpenseChanges(existing, updated)
+          const paidByChange = changes.find((c) => c.field === 'paidBy')
+
+          expect(paidByChange).toBeUndefined()
+        }),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    /**
+     * Validates: Requirements 5.2
+     *
+     * The serializePayers function produces valid JSON that can be parsed back,
+     * and is order-independent (sorting by userId).
+     */
+    it('serializePayers produces order-independent JSON that round-trips', () => {
+      fc.assert(
+        fc.property(arbPayerState, (payers) => {
+          const serialized = serializePayers(payers)
+          const parsed = JSON.parse(serialized) as Array<{
+            userId: string
+            amount: number
+          }>
+
+          // Round-trip: parsed should contain same (userId, amount) pairs
+          expect(payerSetsEqual(parsed, payers)).toBe(true)
+
+          // Order-independence: shuffled input should produce same output
+          const shuffled = [...payers].reverse()
+          const serializedShuffled = serializePayers(shuffled)
+          expect(serializedShuffled).toBe(serialized)
+        }),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+  })
+})

--- a/src/lib/__tests__/api-multi-payer-validation.test.ts
+++ b/src/lib/__tests__/api-multi-payer-validation.test.ts
@@ -1,0 +1,407 @@
+import { TRPCError } from '@trpc/server'
+import { createExpense, updateExpense } from '../api'
+import type { ExpenseFormValues } from '../schemas'
+
+// Mock nanoid
+jest.mock('nanoid', () => ({
+  nanoid: () => 'mocked-nanoid',
+}))
+
+// Mock prisma
+const mockGroupFindUnique = jest.fn()
+const mockExpenseCreate = jest.fn()
+const mockExpenseUpdate = jest.fn()
+const mockExpenseFindFirst = jest.fn()
+const mockActivityCreate = jest.fn()
+const mockRecurringExpenseLinkFindMany = jest.fn()
+const mockExpenseFindMany = jest.fn()
+
+jest.mock('../prisma', () => ({
+  prisma: {
+    group: {
+      findUnique: (...args: unknown[]) => mockGroupFindUnique(...args),
+    },
+    expense: {
+      create: (...args: unknown[]) => mockExpenseCreate(...args),
+      update: (...args: unknown[]) => mockExpenseUpdate(...args),
+      findFirst: (...args: unknown[]) => mockExpenseFindFirst(...args),
+      findMany: (...args: unknown[]) => mockExpenseFindMany(...args),
+    },
+    activity: {
+      create: (...args: unknown[]) => mockActivityCreate(...args),
+    },
+    recurringExpenseLink: {
+      findMany: (...args: unknown[]) =>
+        mockRecurringExpenseLinkFindMany(...args),
+    },
+    expenseCategoryMapping: {
+      upsert: jest.fn(),
+    },
+  },
+}))
+
+// Mock rrule to avoid import issues
+jest.mock('rrule', () => ({
+  RRule: class {
+    static fromString() {
+      return { after: () => new Date() }
+    }
+  },
+}))
+
+// Mock payments module
+jest.mock('../payments', () => ({
+  assertPaymentEditable: jest.fn(),
+}))
+
+const GROUP_ID = 'group-1'
+const MEMBER_A = 'member-a'
+const MEMBER_B = 'member-b'
+const MEMBER_C = 'member-c'
+const NON_MEMBER = 'non-member-user'
+
+function mockGroup(participantIds: string[]) {
+  mockGroupFindUnique.mockResolvedValue({
+    id: GROUP_ID,
+    memberships: participantIds.map((id) => ({
+      user: { id, name: id, email: `${id}@test.com` },
+    })),
+    participants: participantIds.map((id) => ({
+      id,
+      name: id,
+      email: `${id}@test.com`,
+    })),
+  })
+}
+
+function makeExpenseFormValues(
+  overrides: Partial<ExpenseFormValues> = {},
+): ExpenseFormValues {
+  return {
+    expenseDate: new Date('2024-06-15'),
+    title: 'Test Expense',
+    category: 1,
+    amount: 10000,
+    paidBy: [{ participant: MEMBER_A, amount: 10000 }],
+    paidFor: [
+      { participant: MEMBER_A, shares: 1 },
+      { participant: MEMBER_B, shares: 1 },
+    ],
+    splitMode: 'EVENLY',
+    isReimbursement: false,
+    documents: [],
+    notes: '',
+    saveDefaultSplittingOptions: false,
+    recurrenceRule: 'NONE',
+    ...overrides,
+  } as ExpenseFormValues
+}
+
+describe('createExpense multi-payer validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGroup([MEMBER_A, MEMBER_B, MEMBER_C])
+    mockActivityCreate.mockResolvedValue({ id: 'activity-1', changes: [] })
+    mockRecurringExpenseLinkFindMany.mockResolvedValue([])
+    mockExpenseCreate.mockResolvedValue({ id: 'expense-1' })
+  })
+
+  describe('rejects invalid input', () => {
+    it('rejects non-member userId with BAD_REQUEST', async () => {
+      const values = makeExpenseFormValues({
+        paidBy: [{ participant: NON_MEMBER, amount: 10000 }],
+      })
+
+      await expect(createExpense(values, GROUP_ID)).rejects.toThrow(TRPCError)
+      await expect(createExpense(values, GROUP_ID)).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: `User ${NON_MEMBER} is not a group member`,
+      })
+    })
+
+    it('rejects when payer amounts do not sum to expense total', async () => {
+      const values = makeExpenseFormValues({
+        amount: 10000,
+        paidBy: [
+          { participant: MEMBER_A, amount: 6000 },
+          { participant: MEMBER_B, amount: 3000 }, // sum = 9000, not 10000
+        ],
+      })
+
+      await expect(createExpense(values, GROUP_ID)).rejects.toThrow(TRPCError)
+      await expect(createExpense(values, GROUP_ID)).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: 'Payer amounts must sum to expense total',
+      })
+    })
+
+    it('rejects duplicate payer userId with BAD_REQUEST', async () => {
+      const values = makeExpenseFormValues({
+        amount: 10000,
+        paidBy: [
+          { participant: MEMBER_A, amount: 5000 },
+          { participant: MEMBER_A, amount: 5000 }, // duplicate
+        ],
+      })
+
+      await expect(createExpense(values, GROUP_ID)).rejects.toThrow(TRPCError)
+      await expect(createExpense(values, GROUP_ID)).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: `Duplicate payer: ${MEMBER_A}`,
+      })
+    })
+
+    it('rejects when group is not found', async () => {
+      mockGroupFindUnique.mockResolvedValue(null)
+      const values = makeExpenseFormValues()
+
+      await expect(createExpense(values, 'nonexistent-group')).rejects.toThrow(
+        TRPCError,
+      )
+      await expect(
+        createExpense(values, 'nonexistent-group'),
+      ).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'Group not found: nonexistent-group',
+      })
+    })
+  })
+
+  describe('accepts valid input', () => {
+    it('accepts valid multi-payer expense', async () => {
+      const values = makeExpenseFormValues({
+        amount: 10000,
+        paidBy: [
+          { participant: MEMBER_A, amount: 6000 },
+          { participant: MEMBER_B, amount: 4000 },
+        ],
+      })
+
+      await createExpense(values, GROUP_ID)
+
+      expect(mockExpenseCreate).toHaveBeenCalledTimes(1)
+      expect(mockExpenseCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            amount: 10000,
+            paidById: MEMBER_A, // deprecated field set to first payer
+            payers: {
+              createMany: {
+                data: [
+                  { userId: MEMBER_A, amount: 6000 },
+                  { userId: MEMBER_B, amount: 4000 },
+                ],
+              },
+            },
+          }),
+        }),
+      )
+    })
+
+    it('accepts valid single-payer expense', async () => {
+      const values = makeExpenseFormValues({
+        amount: 5000,
+        paidBy: [{ participant: MEMBER_A, amount: 5000 }],
+      })
+
+      await createExpense(values, GROUP_ID)
+
+      expect(mockExpenseCreate).toHaveBeenCalledTimes(1)
+      expect(mockExpenseCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            amount: 5000,
+            paidById: MEMBER_A,
+            payers: {
+              createMany: {
+                data: [{ userId: MEMBER_A, amount: 5000 }],
+              },
+            },
+          }),
+        }),
+      )
+    })
+
+    it('accepts three payers with amounts summing to total', async () => {
+      const values = makeExpenseFormValues({
+        amount: 9000,
+        paidBy: [
+          { participant: MEMBER_A, amount: 3000 },
+          { participant: MEMBER_B, amount: 3000 },
+          { participant: MEMBER_C, amount: 3000 },
+        ],
+        paidFor: [
+          { participant: MEMBER_A, shares: 1 },
+          { participant: MEMBER_B, shares: 1 },
+          { participant: MEMBER_C, shares: 1 },
+        ],
+      })
+
+      await createExpense(values, GROUP_ID)
+
+      expect(mockExpenseCreate).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('updateExpense multi-payer validation', () => {
+  const EXPENSE_ID = 'expense-1'
+
+  const existingExpense = {
+    id: EXPENSE_ID,
+    groupId: GROUP_ID,
+    title: 'Original Expense',
+    amount: 10000,
+    expenseDate: new Date('2024-06-15'),
+    categoryId: 1,
+    paidById: MEMBER_A,
+    splitMode: 'EVENLY',
+    isReimbursement: false,
+    notes: null,
+    recurrenceRule: 'NONE',
+    paidBy: { id: MEMBER_A, name: MEMBER_A, email: `${MEMBER_A}@test.com` },
+    paidFor: [
+      {
+        expenseId: EXPENSE_ID,
+        userId: MEMBER_A,
+        shares: 1,
+        user: { id: MEMBER_A, name: MEMBER_A, email: `${MEMBER_A}@test.com` },
+      },
+      {
+        expenseId: EXPENSE_ID,
+        userId: MEMBER_B,
+        shares: 1,
+        user: { id: MEMBER_B, name: MEMBER_B, email: `${MEMBER_B}@test.com` },
+      },
+    ],
+    payers: [
+      {
+        userId: MEMBER_A,
+        amount: 10000,
+        user: { id: MEMBER_A, name: MEMBER_A },
+      },
+    ],
+    category: { id: 1, grouping: 'General' },
+    documents: [],
+    recurringExpenseLink: null,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGroup([MEMBER_A, MEMBER_B, MEMBER_C])
+    mockExpenseFindFirst.mockResolvedValue(existingExpense)
+    mockActivityCreate.mockResolvedValue({ id: 'activity-1', changes: [] })
+    mockRecurringExpenseLinkFindMany.mockResolvedValue([])
+    mockExpenseUpdate.mockResolvedValue({ id: EXPENSE_ID })
+  })
+
+  describe('rejects invalid input', () => {
+    it('rejects non-member userId with BAD_REQUEST', async () => {
+      const values = makeExpenseFormValues({
+        paidBy: [{ participant: NON_MEMBER, amount: 10000 }],
+      })
+
+      await expect(updateExpense(GROUP_ID, EXPENSE_ID, values)).rejects.toThrow(
+        TRPCError,
+      )
+      await expect(
+        updateExpense(GROUP_ID, EXPENSE_ID, values),
+      ).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: `User ${NON_MEMBER} is not a group member`,
+      })
+    })
+
+    it('rejects amount mismatch with BAD_REQUEST', async () => {
+      const values = makeExpenseFormValues({
+        amount: 10000,
+        paidBy: [
+          { participant: MEMBER_A, amount: 7000 },
+          { participant: MEMBER_B, amount: 2000 }, // sum = 9000
+        ],
+      })
+
+      await expect(updateExpense(GROUP_ID, EXPENSE_ID, values)).rejects.toThrow(
+        TRPCError,
+      )
+      await expect(
+        updateExpense(GROUP_ID, EXPENSE_ID, values),
+      ).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: 'Payer amounts must sum to expense total',
+      })
+    })
+
+    it('rejects duplicate payer with BAD_REQUEST', async () => {
+      const values = makeExpenseFormValues({
+        amount: 10000,
+        paidBy: [
+          { participant: MEMBER_B, amount: 5000 },
+          { participant: MEMBER_B, amount: 5000 },
+        ],
+      })
+
+      await expect(updateExpense(GROUP_ID, EXPENSE_ID, values)).rejects.toThrow(
+        TRPCError,
+      )
+      await expect(
+        updateExpense(GROUP_ID, EXPENSE_ID, values),
+      ).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: `Duplicate payer: ${MEMBER_B}`,
+      })
+    })
+  })
+
+  describe('payer change triggers activity log', () => {
+    it('logs paidBy change when payers are updated', async () => {
+      const values = makeExpenseFormValues({
+        amount: 10000,
+        paidBy: [
+          { participant: MEMBER_A, amount: 6000 },
+          { participant: MEMBER_B, amount: 4000 },
+        ],
+      })
+
+      await updateExpense(GROUP_ID, EXPENSE_ID, values)
+
+      // Activity log should have been called with changes including paidBy
+      expect(mockActivityCreate).toHaveBeenCalledTimes(1)
+      const activityCall = mockActivityCreate.mock.calls[0][0]
+      const changes = activityCall.data.changes?.createMany?.data
+
+      // Find the paidBy change
+      const paidByChange = changes?.find(
+        (c: { field: string }) => c.field === 'paidBy',
+      )
+      expect(paidByChange).toBeDefined()
+      expect(paidByChange.oldValue).toBe(
+        JSON.stringify([{ userId: MEMBER_A, amount: 10000 }]),
+      )
+      // New value should contain both payers (sorted by userId)
+      const newPayers = JSON.parse(paidByChange.newValue)
+      expect(newPayers).toHaveLength(2)
+      expect(newPayers).toContainEqual({ userId: MEMBER_A, amount: 6000 })
+      expect(newPayers).toContainEqual({ userId: MEMBER_B, amount: 4000 })
+    })
+
+    it('does not log paidBy change when payers are unchanged', async () => {
+      const values = makeExpenseFormValues({
+        amount: 10000,
+        paidBy: [{ participant: MEMBER_A, amount: 10000 }],
+      })
+
+      await updateExpense(GROUP_ID, EXPENSE_ID, values)
+
+      expect(mockActivityCreate).toHaveBeenCalledTimes(1)
+      const activityCall = mockActivityCreate.mock.calls[0][0]
+      const changes = activityCall.data.changes?.createMany?.data
+
+      // No paidBy change should be recorded
+      const paidByChange = changes?.find(
+        (c: { field: string }) => c.field === 'paidBy',
+      )
+      expect(paidByChange).toBeUndefined()
+    })
+  })
+})

--- a/src/lib/__tests__/balances-multi-payer.property.test.ts
+++ b/src/lib/__tests__/balances-multi-payer.property.test.ts
@@ -1,0 +1,487 @@
+/**
+ * Property-based tests for multi-payer balance computation.
+ *
+ * Feature: multi-payer-expenses
+ * Uses fast-check for property-based testing with minimum 100 iterations.
+ */
+
+import fc from 'fast-check'
+import { getBalances } from '../balances'
+
+type Expense = Parameters<typeof getBalances>[0][number]
+
+// --- Constants ---
+
+const PBT_NUM_RUNS = 100
+
+// --- Generators ---
+
+const arbSplitMode = fc.constantFrom(
+  'EVENLY' as const,
+  'BY_SHARES' as const,
+  'BY_AMOUNT' as const,
+)
+
+/**
+ * Generate a list of unique participant IDs (2–8 participants).
+ */
+const arbParticipantIds = fc
+  .array(fc.uuid(), { minLength: 2, maxLength: 8 })
+  .map((ids) => Array.from(new Set(ids)))
+  .filter((ids) => ids.length >= 2)
+
+/**
+ * Generate a valid payer distribution for a given total.
+ * Produces 1–N payers whose amounts sum exactly to the total.
+ */
+function arbPayerDistribution(
+  participantIds: string[],
+  total: number,
+): fc.Arbitrary<
+  Array<{ userId: string; amount: number; user: { id: string; name: string } }>
+> {
+  const maxPayers = Math.min(participantIds.length, 5)
+  return fc.integer({ min: 1, max: maxPayers }).chain((numPayers) => {
+    // Pick numPayers unique participant IDs
+    return fc
+      .shuffledSubarray(participantIds, {
+        minLength: numPayers,
+        maxLength: numPayers,
+      })
+      .chain((payerIds) => {
+        // Generate numPayers - 1 amounts that leave a positive remainder for the last
+        if (numPayers === 1) {
+          return fc.constant(
+            payerIds.map((id) => ({
+              userId: id,
+              amount: total,
+              user: { id, name: id },
+            })),
+          )
+        }
+        // Generate amounts for the first N-1 payers, each between 1 and (total - remaining payers)
+        return fc
+          .array(fc.integer({ min: 1, max: Math.max(1, total - numPayers) }), {
+            minLength: numPayers - 1,
+            maxLength: numPayers - 1,
+          })
+          .map((amounts) => {
+            // Normalize so they sum to less than total, leaving at least 1 for last payer
+            const rawSum = amounts.reduce((s, a) => s + a, 0)
+            const scaledAmounts = amounts.map((a) =>
+              Math.max(1, Math.floor((a / rawSum) * (total - 1))),
+            )
+            const scaledSum = scaledAmounts.reduce((s, a) => s + a, 0)
+            const lastAmount = total - scaledSum
+
+            if (lastAmount <= 0) {
+              // Fallback: give everything to the last payer
+              const fallbackAmounts = payerIds.slice(0, -1).map(() => 1)
+              const fallbackLast =
+                total - fallbackAmounts.reduce((s, a) => s + a, 0)
+              return payerIds.map((id, i) => ({
+                userId: id,
+                amount: i < numPayers - 1 ? fallbackAmounts[i] : fallbackLast,
+                user: { id, name: id },
+              }))
+            }
+
+            return payerIds.map((id, i) => ({
+              userId: id,
+              amount: i < numPayers - 1 ? scaledAmounts[i] : lastAmount,
+              user: { id, name: id },
+            }))
+          })
+          .filter((payers) => payers.every((p) => p.amount > 0))
+      })
+  })
+}
+
+/**
+ * Generate paidFor entries for given participants and split mode.
+ */
+function arbPaidFor(
+  participantIds: string[],
+  splitMode: 'EVENLY' | 'BY_SHARES' | 'BY_AMOUNT',
+  total: number,
+): fc.Arbitrary<Array<{ user: { id: string; name: string }; shares: number }>> {
+  // Pick a subset of participants as beneficiaries (at least 1)
+  return fc
+    .shuffledSubarray(participantIds, {
+      minLength: 1,
+      maxLength: participantIds.length,
+    })
+    .chain((beneficiaryIds) => {
+      switch (splitMode) {
+        case 'EVENLY':
+          return fc.constant(
+            beneficiaryIds.map((id) => ({
+              user: { id, name: id },
+              shares: 1,
+            })),
+          )
+        case 'BY_SHARES':
+          return fc
+            .array(fc.integer({ min: 1, max: 100 }), {
+              minLength: beneficiaryIds.length,
+              maxLength: beneficiaryIds.length,
+            })
+            .map((shares) =>
+              beneficiaryIds.map((id, i) => ({
+                user: { id, name: id },
+                shares: shares[i],
+              })),
+            )
+        case 'BY_AMOUNT': {
+          // Generate amounts that sum to total
+          const numBeneficiaries = beneficiaryIds.length
+          if (numBeneficiaries === 1) {
+            return fc.constant([
+              {
+                user: { id: beneficiaryIds[0], name: beneficiaryIds[0] },
+                shares: total,
+              },
+            ])
+          }
+          return fc
+            .array(
+              fc.integer({
+                min: 1,
+                max: Math.max(1, total - numBeneficiaries),
+              }),
+              {
+                minLength: numBeneficiaries - 1,
+                maxLength: numBeneficiaries - 1,
+              },
+            )
+            .map((shares) => {
+              const rawSum = shares.reduce((s, a) => s + a, 0)
+              const scaledShares = shares.map((a) =>
+                Math.max(1, Math.floor((a / rawSum) * (total - 1))),
+              )
+              const scaledSum = scaledShares.reduce((s, a) => s + a, 0)
+              const lastShare = total - scaledSum
+
+              if (lastShare <= 0) {
+                const fallback = beneficiaryIds.slice(0, -1).map(() => 1)
+                const fallbackLast = total - fallback.reduce((s, a) => s + a, 0)
+                return beneficiaryIds.map((id, i) => ({
+                  user: { id, name: id },
+                  shares: i < numBeneficiaries - 1 ? fallback[i] : fallbackLast,
+                }))
+              }
+
+              return beneficiaryIds.map((id, i) => ({
+                user: { id, name: id },
+                shares: i < numBeneficiaries - 1 ? scaledShares[i] : lastShare,
+              }))
+            })
+            .filter((paidFor) => paidFor.every((p) => p.shares > 0))
+        }
+      }
+    })
+}
+
+// --- Tests ---
+
+describe('Multi-Payer Balances — Property-Based Tests', () => {
+  /**
+   * Property 3: PaidFor Independence from Payer Distribution
+   *
+   * **Validates: Requirements 3.2**
+   *
+   * For any expense, the `paidFor` (debit) amounts computed for each beneficiary
+   * SHALL be identical regardless of how the expense total is distributed among payers.
+   * Only the `paidBy` credit side is affected by the payer distribution.
+   */
+  describe('Property 3: PaidFor Independence from Payer Distribution', () => {
+    it('paidFor values are identical regardless of payer distribution', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc.integer({ min: 100, max: 1_000_000 }).chain((total) =>
+              arbSplitMode.chain((splitMode) =>
+                arbPaidFor(ids, splitMode, total).chain((paidFor) =>
+                  fc.tuple(
+                    // Generate two different payer distributions for the same total
+                    arbPayerDistribution(ids, total),
+                    arbPayerDistribution(ids, total),
+                    fc.constant({ ids, total, splitMode, paidFor }),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          ([payerDist1, payerDist2, { ids, total, splitMode, paidFor }]) => {
+            // Create expense with first payer distribution
+            const expense1: Expense = {
+              amount: total,
+              isReimbursement: false,
+              splitMode,
+              paidBy: { id: payerDist1[0].userId, name: payerDist1[0].userId },
+              paidFor,
+              payers: payerDist1,
+            } as Expense
+
+            // Create expense with second payer distribution (same total, same split)
+            const expense2: Expense = {
+              amount: total,
+              isReimbursement: false,
+              splitMode,
+              paidBy: { id: payerDist2[0].userId, name: payerDist2[0].userId },
+              paidFor,
+              payers: payerDist2,
+            } as Expense
+
+            const balances1 = getBalances([expense1])
+            const balances2 = getBalances([expense2])
+
+            // Assert paidFor values are identical for all beneficiaries
+            for (const entry of paidFor) {
+              const userId = entry.user.id
+              const paidFor1 = balances1[userId]?.paidFor ?? 0
+              const paidFor2 = balances2[userId]?.paidFor ?? 0
+              expect(paidFor1).toBe(paidFor2)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('paidFor values are unchanged between single-payer and multi-payer for same expense total', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc.integer({ min: 100, max: 1_000_000 }).chain((total) =>
+              arbSplitMode.chain((splitMode) =>
+                arbPaidFor(ids, splitMode, total).chain((paidFor) =>
+                  fc.tuple(
+                    // Single payer (one person pays everything)
+                    fc.constantFrom(...ids).map((payerId) => [
+                      {
+                        userId: payerId,
+                        amount: total,
+                        user: { id: payerId, name: payerId },
+                      },
+                    ]),
+                    // Multi-payer distribution
+                    arbPayerDistribution(ids, total),
+                    fc.constant({ ids, total, splitMode, paidFor }),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          ([singlePayer, multiPayer, { total, splitMode, paidFor }]) => {
+            const singlePayerExpense: Expense = {
+              amount: total,
+              isReimbursement: false,
+              splitMode,
+              paidBy: {
+                id: singlePayer[0].userId,
+                name: singlePayer[0].userId,
+              },
+              paidFor,
+              payers: singlePayer,
+            } as Expense
+
+            const multiPayerExpense: Expense = {
+              amount: total,
+              isReimbursement: false,
+              splitMode,
+              paidBy: { id: multiPayer[0].userId, name: multiPayer[0].userId },
+              paidFor,
+              payers: multiPayer,
+            } as Expense
+
+            const singleBalances = getBalances([singlePayerExpense])
+            const multiBalances = getBalances([multiPayerExpense])
+
+            // Assert paidFor values are identical for ALL users in the system
+            const allUserIds = Array.from(
+              new Set([
+                ...Object.keys(singleBalances),
+                ...Object.keys(multiBalances),
+              ]),
+            )
+
+            for (const userId of allUserIds) {
+              const paidForSingle = singleBalances[userId]?.paidFor ?? 0
+              const paidForMulti = multiBalances[userId]?.paidFor ?? 0
+              expect(paidForSingle).toBe(paidForMulti)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+  })
+
+  /**
+   * Property 4: Single-Payer Backward Compatibility
+   *
+   * **Validates: Requirements 3.4**
+   *
+   * For any expense with exactly one payer whose amount equals the expense total,
+   * the balance calculator SHALL produce identical `paid`, `paidFor`, and `total`
+   * values to the current single-payer computation (legacy path using paidBy.id
+   * with empty payers array).
+   */
+  describe('Property 4: Single-Payer Backward Compatibility', () => {
+    it('single-payer expense with payers array produces identical balances to legacy paidBy path', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc.integer({ min: 1, max: 10_000_000 }).chain((total) =>
+              arbSplitMode.chain((splitMode) =>
+                arbPaidFor(ids, splitMode, total).chain((paidFor) =>
+                  fc.constantFrom(...ids).map((payerId) => ({
+                    ids,
+                    total,
+                    splitMode,
+                    paidFor,
+                    payerId,
+                  })),
+                ),
+              ),
+            ),
+          ),
+          ({ ids, total, splitMode, paidFor, payerId }) => {
+            // Multi-payer format: payers array with a single entry
+            const multiPayerExpense: Expense = {
+              amount: total,
+              isReimbursement: false,
+              splitMode,
+              paidBy: { id: payerId, name: payerId },
+              paidFor,
+              payers: [
+                {
+                  userId: payerId,
+                  amount: total,
+                  user: { id: payerId, name: payerId },
+                },
+              ],
+            } as Expense
+
+            // Legacy format: empty payers array, falls back to paidBy.id
+            const legacyExpense = {
+              amount: total,
+              isReimbursement: false,
+              splitMode,
+              paidBy: { id: payerId, name: payerId },
+              paidFor,
+              payers: [],
+            } as unknown as Expense
+
+            const multiResult = getBalances([multiPayerExpense])
+            const legacyResult = getBalances([legacyExpense])
+
+            // All participant balances must be identical
+            const allParticipantIds = Array.from(
+              new Set([
+                ...Object.keys(multiResult),
+                ...Object.keys(legacyResult),
+              ]),
+            )
+
+            for (const id of allParticipantIds) {
+              const multi = multiResult[id] ?? { paid: 0, paidFor: 0, total: 0 }
+              const legacy = legacyResult[id] ?? {
+                paid: 0,
+                paidFor: 0,
+                total: 0,
+              }
+
+              expect(multi.paid).toBe(legacy.paid)
+              expect(multi.paidFor).toBe(legacy.paidFor)
+              expect(multi.total).toBe(legacy.total)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('single-payer backward compatibility holds across multiple expenses', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc
+              .array(
+                fc.integer({ min: 1, max: 10_000_000 }).chain((total) =>
+                  arbSplitMode.chain((splitMode) =>
+                    arbPaidFor(ids, splitMode, total).chain((paidFor) =>
+                      fc.constantFrom(...ids).map((payerId) => ({
+                        total,
+                        splitMode,
+                        paidFor,
+                        payerId,
+                      })),
+                    ),
+                  ),
+                ),
+                { minLength: 1, maxLength: 5 },
+              )
+              .map((exps) => ({ ids, exps })),
+          ),
+          ({ ids, exps }) => {
+            const multiPayerExpenses: Expense[] = exps.map(
+              ({ total, splitMode, paidFor, payerId }) =>
+                ({
+                  amount: total,
+                  isReimbursement: false,
+                  splitMode,
+                  paidBy: { id: payerId, name: payerId },
+                  paidFor,
+                  payers: [
+                    {
+                      userId: payerId,
+                      amount: total,
+                      user: { id: payerId, name: payerId },
+                    },
+                  ],
+                }) as Expense,
+            )
+
+            const legacyExpenses: Expense[] = exps.map(
+              ({ total, splitMode, paidFor, payerId }) =>
+                ({
+                  amount: total,
+                  isReimbursement: false,
+                  splitMode,
+                  paidBy: { id: payerId, name: payerId },
+                  paidFor,
+                  payers: [],
+                }) as unknown as Expense,
+            )
+
+            const multiResult = getBalances(multiPayerExpenses)
+            const legacyResult = getBalances(legacyExpenses)
+
+            const allParticipantIds = Array.from(
+              new Set([
+                ...Object.keys(multiResult),
+                ...Object.keys(legacyResult),
+              ]),
+            )
+
+            for (const id of allParticipantIds) {
+              const multi = multiResult[id] ?? { paid: 0, paidFor: 0, total: 0 }
+              const legacy = legacyResult[id] ?? {
+                paid: 0,
+                paidFor: 0,
+                total: 0,
+              }
+
+              expect(multi.paid).toBe(legacy.paid)
+              expect(multi.paidFor).toBe(legacy.paidFor)
+              expect(multi.total).toBe(legacy.total)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+  })
+})

--- a/src/lib/__tests__/export-multi-payer.property.test.ts
+++ b/src/lib/__tests__/export-multi-payer.property.test.ts
@@ -1,0 +1,518 @@
+/**
+ * Property-based tests for multi-payer CSV export.
+ *
+ * Feature: multi-payer-expenses
+ * Uses fast-check for property-based testing with minimum 100 iterations.
+ */
+
+import { Currency } from '@/lib/currency'
+import { formatAmountAsDecimal } from '@/lib/utils'
+import fc from 'fast-check'
+
+// --- Constants ---
+
+const PBT_NUM_RUNS = 100
+
+// A standard 2-decimal-digit currency for testing
+const TEST_CURRENCY: Currency = {
+  name: 'US Dollar',
+  symbol_native: '$',
+  symbol: '$',
+  code: 'USD',
+  name_plural: 'US dollars',
+  rounding: 0,
+  decimal_digits: 2,
+}
+
+// --- Types ---
+
+interface PaidForEntry {
+  userId: string
+  shares: number
+}
+
+interface PayerEntry {
+  userId: string
+  amount: number
+}
+
+// --- CSV Column Computation Functions ---
+
+/**
+ * New multi-payer code: single-payer backward-compatible path.
+ * Mirrors the `isSinglePayer` branch in the CSV export route.
+ */
+function computeColumnNewCode(
+  participantId: string,
+  payers: PayerEntry[],
+  paidById: string,
+  paidFor: PaidForEntry[],
+  expenseAmount: number,
+  currency: Currency,
+): number {
+  const totalShares = paidFor.reduce((acc, entry) => acc + entry.shares, 0)
+  const participantPaidFor = paidFor.find((e) => e.userId === participantId)
+  const participantShare = participantPaidFor ? participantPaidFor.shares : 0
+
+  const isSinglePayer = payers.length <= 1
+
+  if (isSinglePayer) {
+    // Single-payer: preserve backward-compatible format
+    // Payer column = +share, non-payer column = -share
+    const isPaidByParticipant =
+      (payers.length === 1 && payers[0].userId === participantId) ||
+      (payers.length === 0 && paidById === participantId)
+
+    const participantAmountShare =
+      totalShares === 0
+        ? 0
+        : +formatAmountAsDecimal(
+            (expenseAmount / totalShares) * participantShare,
+            currency,
+          )
+
+    return participantAmountShare * (isPaidByParticipant ? 1 : -1)
+  }
+
+  // This path should not be reached for single-payer expenses
+  throw new Error('Expected single-payer expense')
+}
+
+/**
+ * Legacy/old code: original single-payer CSV export logic.
+ * Before multi-payer was introduced, the code used `paidById` directly.
+ * Payer column = +share, non-payer column = -share.
+ */
+function computeColumnLegacyCode(
+  participantId: string,
+  paidById: string,
+  paidFor: PaidForEntry[],
+  expenseAmount: number,
+  currency: Currency,
+): number {
+  const totalShares = paidFor.reduce((acc, entry) => acc + entry.shares, 0)
+  const participantPaidFor = paidFor.find((e) => e.userId === participantId)
+  const participantShare = participantPaidFor ? participantPaidFor.shares : 0
+
+  const isPaidByParticipant = paidById === participantId
+  const participantAmountShare =
+    totalShares === 0
+      ? 0
+      : +formatAmountAsDecimal(
+          (expenseAmount / totalShares) * participantShare,
+          currency,
+        )
+
+  return participantAmountShare * (isPaidByParticipant ? 1 : -1)
+}
+
+// --- Generators ---
+
+/**
+ * Generate a list of unique participant IDs (2–6 participants).
+ */
+const arbParticipantIds = fc
+  .array(fc.uuid(), { minLength: 2, maxLength: 6 })
+  .map((ids) => Array.from(new Set(ids)))
+  .filter((ids) => ids.length >= 2)
+
+/**
+ * Generate valid paidFor entries for the given participants.
+ * Each beneficiary gets at least 1 share.
+ */
+function arbPaidFor(participantIds: string[]): fc.Arbitrary<PaidForEntry[]> {
+  return fc
+    .shuffledSubarray(participantIds, {
+      minLength: 1,
+      maxLength: participantIds.length,
+    })
+    .chain((beneficiaryIds) =>
+      fc
+        .array(fc.integer({ min: 1, max: 100 }), {
+          minLength: beneficiaryIds.length,
+          maxLength: beneficiaryIds.length,
+        })
+        .map((shares) =>
+          beneficiaryIds.map((id, i) => ({
+            userId: id,
+            shares: shares[i],
+          })),
+        ),
+    )
+}
+
+/**
+ * Multi-payer CSV column calculation — mirrors the route handler logic.
+ * For multi-payer expenses: net position = payer credit - beneficiary debit.
+ */
+function computeColumnMultiPayer(
+  participantId: string,
+  payers: PayerEntry[],
+  paidFor: PaidForEntry[],
+  expenseAmount: number,
+  currency: Currency,
+): number {
+  const totalShares = paidFor.reduce((acc, entry) => acc + entry.shares, 0)
+  const participantPaidFor = paidFor.find((e) => e.userId === participantId)
+  const participantShare = participantPaidFor ? participantPaidFor.shares : 0
+
+  // Beneficiary debit
+  const debit =
+    totalShares === 0 ? 0 : (expenseAmount / totalShares) * participantShare
+
+  // Payer credit from payers array
+  const payerEntry = payers.find((p) => p.userId === participantId)
+  const credit = payerEntry ? payerEntry.amount : 0
+
+  // Net amount: payer credit (positive) minus beneficiary debit (negative)
+  const net = credit - debit
+  return +formatAmountAsDecimal(net, currency)
+}
+
+/**
+ * Generate a multi-payer distribution (2+ payers) whose amounts sum exactly to total.
+ */
+function arbMultiPayerDistribution(
+  participantIds: string[],
+  total: number,
+): fc.Arbitrary<PayerEntry[]> {
+  const maxPayers = Math.min(participantIds.length, 5)
+  return fc
+    .integer({ min: 2, max: Math.max(2, maxPayers) })
+    .chain((numPayers) => {
+      return fc
+        .shuffledSubarray(participantIds, {
+          minLength: numPayers,
+          maxLength: numPayers,
+        })
+        .chain((payerIds) => {
+          if (numPayers === 1) {
+            return fc.constant([{ userId: payerIds[0], amount: total }])
+          }
+          return fc
+            .array(
+              fc.integer({ min: 1, max: Math.max(1, total - numPayers) }),
+              { minLength: numPayers - 1, maxLength: numPayers - 1 },
+            )
+            .map((amounts) => {
+              const rawSum = amounts.reduce((s, a) => s + a, 0)
+              const scaledAmounts = amounts.map((a) =>
+                Math.max(1, Math.floor((a / rawSum) * (total - 1))),
+              )
+              const scaledSum = scaledAmounts.reduce((s, a) => s + a, 0)
+              const lastAmount = total - scaledSum
+
+              if (lastAmount <= 0) {
+                const fallbackAmounts = payerIds.slice(0, -1).map(() => 1)
+                const fallbackLast =
+                  total - fallbackAmounts.reduce((s, a) => s + a, 0)
+                return payerIds.map((id, i) => ({
+                  userId: id,
+                  amount: i < numPayers - 1 ? fallbackAmounts[i] : fallbackLast,
+                }))
+              }
+
+              return payerIds.map((id, i) => ({
+                userId: id,
+                amount: i < numPayers - 1 ? scaledAmounts[i] : lastAmount,
+              }))
+            })
+            .filter((payers) => payers.every((p) => p.amount > 0))
+        })
+    })
+}
+
+// --- Tests ---
+
+describe('Multi-Payer CSV Export — Property-Based Tests', () => {
+  /**
+   * Property 11: CSV Export Per-Participant Values
+   *
+   * **Validates: Requirements 9.1, 9.2**
+   *
+   * For any expense with multiple payers, the CSV export SHALL output per-participant
+   * column values where each payer's column equals their credit (positive) minus their
+   * beneficiary debit (if any), and each non-payer beneficiary's column equals their
+   * negative debit. The sum of all participant columns SHALL equal zero.
+   */
+  describe('Property 11: CSV Export Per-Participant Values', () => {
+    it('sum of all participant columns equals zero for multi-payer expenses', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc
+              .integer({ min: 100, max: 10_000_00 }) // 100 to 10000.00 in minor units
+              .chain((total) =>
+                arbPaidFor(ids).chain((paidFor) =>
+                  arbMultiPayerDistribution(ids, total).map((payers) => ({
+                    participantIds: ids,
+                    expenseAmount: total,
+                    paidFor,
+                    payers,
+                  })),
+                ),
+              ),
+          ),
+          ({ participantIds, expenseAmount, paidFor, payers }) => {
+            const columns: Record<string, number> = {}
+
+            for (const participantId of participantIds) {
+              columns[participantId] = computeColumnMultiPayer(
+                participantId,
+                payers,
+                paidFor,
+                expenseAmount,
+                TEST_CURRENCY,
+              )
+            }
+
+            // Sum of all participant columns should equal zero
+            // (one person's credit is another's debit)
+            const sum = Object.values(columns).reduce((s, v) => s + v, 0)
+
+            // Allow for floating point rounding tolerance
+            expect(Math.abs(sum)).toBeLessThanOrEqual(
+              0.01 * participantIds.length,
+            )
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('payer-only columns are positive and non-payer beneficiary columns are non-positive', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc.integer({ min: 100, max: 10_000_00 }).chain((total) =>
+              arbPaidFor(ids).chain((paidFor) =>
+                arbMultiPayerDistribution(ids, total).map((payers) => ({
+                  participantIds: ids,
+                  expenseAmount: total,
+                  paidFor,
+                  payers,
+                })),
+              ),
+            ),
+          ),
+          ({ participantIds, expenseAmount, paidFor, payers }) => {
+            const payerIds = new Set(payers.map((p) => p.userId))
+            const beneficiaryIds = new Set(paidFor.map((p) => p.userId))
+
+            for (const participantId of participantIds) {
+              const column = computeColumnMultiPayer(
+                participantId,
+                payers,
+                paidFor,
+                expenseAmount,
+                TEST_CURRENCY,
+              )
+
+              const isPayer = payerIds.has(participantId)
+              const isBeneficiary = beneficiaryIds.has(participantId)
+
+              if (!isPayer && isBeneficiary) {
+                // Non-payer beneficiaries should have negative (debit) columns
+                expect(column).toBeLessThanOrEqual(0)
+              } else if (isPayer && !isBeneficiary) {
+                // Payers who are not beneficiaries should have positive (credit) columns
+                expect(column).toBeGreaterThanOrEqual(0)
+              }
+              // If both payer and beneficiary, the net can be positive or negative
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+  })
+
+  /**
+   * Property 12: CSV Export Single-Payer Backward Compatibility
+   *
+   * **Validates: Requirements 9.3**
+   *
+   * For any single-payer expense, the CSV export produced by the multi-payer
+   * code SHALL be byte-identical to the output of the current single-payer
+   * export logic.
+   */
+  describe('Property 12: CSV Export Single-Payer Backward Compatibility', () => {
+    it('single-payer CSV column values from new code match legacy code for all participants', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc.integer({ min: 100, max: 10_000_000 }).chain((expenseAmount) =>
+              arbPaidFor(ids).chain((paidFor) =>
+                fc.constantFrom(...ids).map((payerId) => ({
+                  participantIds: ids,
+                  expenseAmount,
+                  paidFor,
+                  payerId,
+                })),
+              ),
+            ),
+          ),
+          ({ participantIds, expenseAmount, paidFor, payerId }) => {
+            const payers: PayerEntry[] = [
+              { userId: payerId, amount: expenseAmount },
+            ]
+
+            for (const participantId of participantIds) {
+              const newValue = computeColumnNewCode(
+                participantId,
+                payers,
+                payerId,
+                paidFor,
+                expenseAmount,
+                TEST_CURRENCY,
+              )
+
+              const legacyValue = computeColumnLegacyCode(
+                participantId,
+                payerId,
+                paidFor,
+                expenseAmount,
+                TEST_CURRENCY,
+              )
+
+              expect(newValue).toBe(legacyValue)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('single-payer CSV column values are identical across different currencies', () => {
+      const currencies: Currency[] = [
+        TEST_CURRENCY,
+        {
+          name: 'Japanese Yen',
+          symbol_native: '¥',
+          symbol: '¥',
+          code: 'JPY',
+          name_plural: 'Japanese yen',
+          rounding: 0,
+          decimal_digits: 0,
+        },
+        {
+          name: 'Euro',
+          symbol_native: '€',
+          symbol: '€',
+          code: 'EUR',
+          name_plural: 'euros',
+          rounding: 0,
+          decimal_digits: 2,
+        },
+      ]
+
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc.integer({ min: 100, max: 10_000_000 }).chain((expenseAmount) =>
+              arbPaidFor(ids).chain((paidFor) =>
+                fc.constantFrom(...ids).chain((payerId) =>
+                  fc.constantFrom(...currencies).map((currency) => ({
+                    participantIds: ids,
+                    expenseAmount,
+                    paidFor,
+                    payerId,
+                    currency,
+                  })),
+                ),
+              ),
+            ),
+          ),
+          ({ participantIds, expenseAmount, paidFor, payerId, currency }) => {
+            const payers: PayerEntry[] = [
+              { userId: payerId, amount: expenseAmount },
+            ]
+
+            for (const participantId of participantIds) {
+              const newValue = computeColumnNewCode(
+                participantId,
+                payers,
+                payerId,
+                paidFor,
+                expenseAmount,
+                currency,
+              )
+
+              const legacyValue = computeColumnLegacyCode(
+                participantId,
+                payerId,
+                paidFor,
+                expenseAmount,
+                currency,
+              )
+
+              expect(newValue).toBe(legacyValue)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('non-beneficiary payer column is zero for both new and legacy code', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds
+            .filter((ids) => ids.length >= 3)
+            .chain((ids) => {
+              // Pick a payer who is NOT a beneficiary
+              return fc
+                .integer({ min: 100, max: 10_000_000 })
+                .chain((expenseAmount) => {
+                  // Use only a subset as beneficiaries (not all participants)
+                  const beneficiaryIds = ids.slice(1) // first participant excluded
+                  const payerId = ids[0] // payer is NOT in beneficiaries
+
+                  const paidFor: PaidForEntry[] = beneficiaryIds.map((id) => ({
+                    userId: id,
+                    shares: 1,
+                  }))
+
+                  return fc.constant({
+                    participantIds: ids,
+                    expenseAmount,
+                    paidFor,
+                    payerId,
+                  })
+                })
+            }),
+          ({ participantIds, expenseAmount, paidFor, payerId }) => {
+            const payers: PayerEntry[] = [
+              { userId: payerId, amount: expenseAmount },
+            ]
+
+            // The payer is not a beneficiary, so their share is 0
+            // Legacy: isPaidByParticipant=true, share=0 → 0 * 1 = 0
+            // New: isPaidByParticipant=true, share=0 → 0 * 1 = 0
+            const newValue = computeColumnNewCode(
+              payerId,
+              payers,
+              payerId,
+              paidFor,
+              expenseAmount,
+              TEST_CURRENCY,
+            )
+
+            const legacyValue = computeColumnLegacyCode(
+              payerId,
+              payerId,
+              paidFor,
+              expenseAmount,
+              TEST_CURRENCY,
+            )
+
+            expect(newValue).toBe(0)
+            expect(legacyValue).toBe(0)
+            expect(newValue).toBe(legacyValue)
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+  })
+})

--- a/src/lib/__tests__/knots-import-multi-payer.property.test.ts
+++ b/src/lib/__tests__/knots-import-multi-payer.property.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Property-based tests for Knots JSON multi-payer import.
+ *
+ * Feature: multi-payer-expenses
+ * Uses fast-check for property-based testing with minimum 100 iterations.
+ */
+
+import { parseKnotsExport } from '@/lib/knots-import'
+import { prisma } from '@/lib/prisma'
+import fc from 'fast-check'
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    group: {
+      findUnique: jest.fn(),
+    },
+    category: {
+      findMany: jest.fn(),
+    },
+  },
+}))
+
+const mockGroupFindUnique = prisma.group.findUnique as jest.Mock
+const mockCategoryFindMany = prisma.category.findMany as jest.Mock
+
+// --- Constants ---
+
+const PBT_NUM_RUNS = 100
+
+// --- Generators ---
+
+/**
+ * Generate a valid participant name (alphabetic, non-empty, no substrings of each other).
+ */
+const arbParticipantName = fc
+  .stringMatching(/^[A-Z][a-z]{2,7} [A-Z][a-z]{2,7}$/)
+  .filter((name) => name.length >= 5)
+
+/**
+ * Generate a set of group members with unique, non-overlapping names.
+ */
+function arbGroupMembers(minCount: number, maxCount: number) {
+  return fc
+    .array(
+      fc.record({
+        id: fc.uuid(),
+        name: arbParticipantName,
+      }),
+      { minLength: maxCount + 2, maxLength: maxCount + 5 },
+    )
+    .map((members) => {
+      // Deduplicate by name (case-insensitive) and filter out substrings
+      const unique: Array<{ id: string; name: string }> = []
+      const seenNames = new Set<string>()
+      for (const m of members) {
+        const lower = m.name.toLowerCase()
+        if (seenNames.has(lower)) continue
+        // Ensure no name is a substring of another already-selected name
+        const isSubstring = unique.some(
+          (existing) =>
+            existing.name.toLowerCase().includes(lower) ||
+            lower.includes(existing.name.toLowerCase()),
+        )
+        if (isSubstring) continue
+        seenNames.add(lower)
+        unique.push(m)
+        if (unique.length >= maxCount) break
+      }
+      return unique
+    })
+    .filter((members) => members.length >= minCount)
+    .map((members) => members.slice(0, maxCount))
+}
+
+/**
+ * Generate a valid paidBy array with M entries (1 to numParticipants)
+ * whose amounts are positive integers summing to the given total.
+ */
+function arbPaidByArray(
+  participantIds: string[],
+  total: number,
+): fc.Arbitrary<Array<{ userId: string; amount: number }>> {
+  const maxPayers = Math.min(participantIds.length, 5)
+  return fc.integer({ min: 1, max: maxPayers }).chain((numPayers) =>
+    fc
+      .shuffledSubarray(participantIds, {
+        minLength: numPayers,
+        maxLength: numPayers,
+      })
+      .chain((payerIds) => {
+        if (numPayers === 1) {
+          return fc.constant([{ userId: payerIds[0], amount: total }])
+        }
+        // Generate amounts for first N-1 payers, remainder goes to last
+        return fc
+          .array(fc.integer({ min: 1, max: Math.max(1, total - numPayers) }), {
+            minLength: numPayers - 1,
+            maxLength: numPayers - 1,
+          })
+          .map((rawAmounts) => {
+            const rawSum = rawAmounts.reduce((s, a) => s + a, 0)
+            const scaledAmounts = rawAmounts.map((a) =>
+              Math.max(1, Math.floor((a / rawSum) * (total - 1))),
+            )
+            const scaledSum = scaledAmounts.reduce((s, a) => s + a, 0)
+            const lastAmount = total - scaledSum
+
+            if (lastAmount <= 0) {
+              // Fallback: evenly distribute with remainder to last
+              const fallback = payerIds.slice(0, -1).map(() => 1)
+              const fallbackLast = total - fallback.reduce((s, a) => s + a, 0)
+              return payerIds.map((id, i) => ({
+                userId: id,
+                amount: i < numPayers - 1 ? fallback[i] : fallbackLast,
+              }))
+            }
+
+            return payerIds.map((id, i) => ({
+              userId: id,
+              amount: i < numPayers - 1 ? scaledAmounts[i] : lastAmount,
+            }))
+          })
+          .filter((payers) => payers.every((p) => p.amount > 0))
+      }),
+  )
+}
+
+/**
+ * Generate a paidFor array for the given participants and total.
+ */
+function arbPaidFor(
+  participantIds: string[],
+  total: number,
+): fc.Arbitrary<Array<{ userId: string; shares: number }>> {
+  return fc
+    .shuffledSubarray(participantIds, {
+      minLength: 1,
+      maxLength: participantIds.length,
+    })
+    .map((beneficiaryIds) => {
+      const numBeneficiaries = beneficiaryIds.length
+      const share = Math.floor(total / numBeneficiaries)
+      const remainder = total - share * numBeneficiaries
+      return beneficiaryIds.map((id, i) => ({
+        userId: id,
+        shares: share + (i === numBeneficiaries - 1 ? remainder : 0),
+      }))
+    })
+    .filter((entries) => entries.every((e) => e.shares > 0))
+}
+
+/**
+ * Generate a Knots JSON export where at least one payer userId references
+ * a participant whose name does NOT match any group member.
+ */
+function arbKnotsExportWithNonMemberPayer() {
+  return arbGroupMembers(2, 5).chain((groupMembers) => {
+    const nonMemberNameArb = fc
+      .record({
+        id: fc.uuid(),
+        name: arbParticipantName,
+      })
+      .filter((nonMember) => {
+        const lower = nonMember.name.toLowerCase()
+        return !groupMembers.some(
+          (m) =>
+            m.name.toLowerCase() === lower ||
+            m.name.toLowerCase().includes(lower) ||
+            lower.includes(m.name.toLowerCase()),
+        )
+      })
+
+    return nonMemberNameArb.chain((nonMember) =>
+      fc
+        .record({
+          expenseTotal: fc.integer({ min: 200, max: 1_000_000 }),
+          nonMemberPayerAmount: fc.integer({ min: 1, max: 100 }),
+        })
+        .map(({ expenseTotal, nonMemberPayerAmount }) => {
+          const clampedNonMemberAmount = Math.min(
+            nonMemberPayerAmount,
+            expenseTotal - 1,
+          )
+          const memberPayerAmount = expenseTotal - clampedNonMemberAmount
+
+          const validPayer = groupMembers[0]
+          const beneficiary = groupMembers[1] || groupMembers[0]
+
+          const allParticipants = [
+            ...groupMembers.map((m) => ({ id: m.id, name: m.name })),
+            { id: nonMember.id, name: nonMember.name },
+          ]
+
+          const exportData = {
+            participants: allParticipants,
+            expenses: [
+              {
+                expenseDate: '2024-01-15T00:00:00.000Z',
+                title: 'Test Expense',
+                amount: expenseTotal,
+                paidById: validPayer.id,
+                paidBy: [
+                  { userId: validPayer.id, amount: memberPayerAmount },
+                  { userId: nonMember.id, amount: clampedNonMemberAmount },
+                ],
+                paidFor: [
+                  {
+                    userId: validPayer.id,
+                    shares: Math.floor(expenseTotal / 2),
+                  },
+                  {
+                    userId: beneficiary.id,
+                    shares: expenseTotal - Math.floor(expenseTotal / 2),
+                  },
+                ],
+                isReimbursement: false,
+                splitMode: 'EVENLY' as const,
+              },
+            ],
+          }
+
+          return {
+            groupMembers,
+            nonMemberName: nonMember.name,
+            exportJson: JSON.stringify(exportData),
+          }
+        }),
+    )
+  })
+}
+
+// --- Tests ---
+
+describe('Knots Import Multi-Payer — Property-Based Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCategoryFindMany.mockResolvedValue([
+      { id: 1, name: 'General', grouping: 'Uncategorized' },
+    ])
+  })
+
+  /**
+   * Property 9: Knots JSON Multi-Payer Import
+   *
+   * **Validates: Requirements 8.1**
+   *
+   * For any Knots JSON export expense containing a `paidBy` array with M entries,
+   * the importer SHALL create exactly M ExpensePaidBy rows with matching userIds
+   * and amounts.
+   */
+  describe('Property 9: Knots JSON Multi-Payer Import', () => {
+    it('M entries in paidBy array → M paidBy entries with matching participant/amount', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          arbGroupMembers(2, 6).chain((members) => {
+            const ids = members.map((m) => m.id)
+            return fc
+              .integer({ min: 100, max: 1_000_000 })
+              .chain((total) =>
+                fc.tuple(
+                  arbPaidByArray(ids, total),
+                  arbPaidFor(ids, total),
+                  fc.constant({ members, total }),
+                ),
+              )
+          }),
+          async ([paidByArray, paidFor, { members, total }]) => {
+            // Set up mock: group has exactly these participants as members
+            mockGroupFindUnique.mockResolvedValue({
+              id: 'group-1',
+              memberships: members.map((m) => ({
+                user: { id: m.id, name: m.name },
+              })),
+            })
+
+            const exportJson = JSON.stringify({
+              participants: members.map((m) => ({ id: m.id, name: m.name })),
+              expenses: [
+                {
+                  expenseDate: '2024-01-15T00:00:00.000Z',
+                  title: 'Test Expense',
+                  category: { name: 'General' },
+                  amount: total,
+                  paidById: paidByArray[0].userId,
+                  paidBy: paidByArray,
+                  paidFor,
+                  isReimbursement: false,
+                  splitMode: 'EVENLY',
+                },
+              ],
+            })
+
+            const expenses = await parseKnotsExport(exportJson, 'group-1')
+
+            // Assert: exactly M paidBy entries
+            expect(expenses).toHaveLength(1)
+            expect(expenses[0].paidBy).toHaveLength(paidByArray.length)
+
+            // Assert: each entry has matching participant ID and amount
+            for (let i = 0; i < paidByArray.length; i++) {
+              expect(expenses[0].paidBy[i].participant).toBe(
+                paidByArray[i].userId,
+              )
+              expect(expenses[0].paidBy[i].amount).toBe(paidByArray[i].amount)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('paidBy array with varying M (1 to max participants) produces correct count across multiple expenses', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          arbGroupMembers(2, 6).chain((members) => {
+            const ids = members.map((m) => m.id)
+            return fc
+              .array(
+                fc
+                  .integer({ min: 100, max: 500_000 })
+                  .chain((total) =>
+                    fc.tuple(
+                      arbPaidByArray(ids, total),
+                      arbPaidFor(ids, total),
+                      fc.constant(total),
+                    ),
+                  ),
+                { minLength: 1, maxLength: 3 },
+              )
+              .map((expenseData) => ({ members, expenseData }))
+          }),
+          async ({ members, expenseData }) => {
+            mockGroupFindUnique.mockResolvedValue({
+              id: 'group-1',
+              memberships: members.map((m) => ({
+                user: { id: m.id, name: m.name },
+              })),
+            })
+
+            const expenses = expenseData.map(
+              ([paidByArray, paidFor, total], idx) => ({
+                expenseDate: `2024-01-${String(idx + 1).padStart(2, '0')}T00:00:00.000Z`,
+                title: `Expense ${idx + 1}`,
+                category: { name: 'General' },
+                amount: total,
+                paidById: paidByArray[0].userId,
+                paidBy: paidByArray,
+                paidFor,
+                isReimbursement: false,
+                splitMode: 'EVENLY' as const,
+              }),
+            )
+
+            const exportJson = JSON.stringify({
+              participants: members.map((m) => ({ id: m.id, name: m.name })),
+              expenses,
+            })
+
+            const result = await parseKnotsExport(exportJson, 'group-1')
+
+            // Assert: each expense has the correct number of paidBy entries
+            expect(result).toHaveLength(expenseData.length)
+            for (let i = 0; i < expenseData.length; i++) {
+              const [paidByArray] = expenseData[i]
+              expect(result[i].paidBy).toHaveLength(paidByArray.length)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+  })
+
+  /**
+   * Property 10: Payer UserId Validation
+   *
+   * **Validates: Requirements 1.6, 8.3, 11.4, 11.5**
+   *
+   * For any expense creation or update request, if any payer's userId maps to a
+   * participant name that is not a member of the target group, the system SHALL
+   * reject the request with a descriptive error.
+   */
+  describe('Property 10: Payer UserId Validation', () => {
+    it('non-member userId in paidBy array causes rejection with descriptive error', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          arbKnotsExportWithNonMemberPayer(),
+          async ({ groupMembers, nonMemberName, exportJson }) => {
+            // Mock the group to only contain the valid members (not the non-member)
+            mockGroupFindUnique.mockResolvedValue({
+              id: 'test-group',
+              memberships: groupMembers.map((m) => ({
+                user: { id: m.id, name: m.name },
+              })),
+            })
+
+            // parseKnotsExport should reject because the non-member payer can't
+            // be matched to a group member
+            await expect(
+              parseKnotsExport(exportJson, 'test-group'),
+            ).rejects.toThrow()
+
+            // Additionally verify the error message references the non-member
+            try {
+              await parseKnotsExport(exportJson, 'test-group')
+            } catch (error) {
+              expect(error).toBeInstanceOf(Error)
+              const message = (error as Error).message
+              // The error should mention either the non-member name or "not in the group"
+              const mentionsNonMember =
+                message.includes(nonMemberName) ||
+                message.includes('not in the group')
+              expect(mentionsNonMember).toBe(true)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+  })
+})

--- a/src/lib/__tests__/migration-multi-payer.property.test.ts
+++ b/src/lib/__tests__/migration-multi-payer.property.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Property-based tests for multi-payer migration correctness.
+ *
+ * Feature: multi-payer-expenses
+ * Uses fast-check for property-based testing with minimum 100 iterations.
+ */
+
+import fc from 'fast-check'
+import { getBalances } from '../balances'
+
+type Expense = Parameters<typeof getBalances>[0][number]
+
+// --- Constants ---
+
+const PBT_NUM_RUNS = 100
+
+// --- Generators ---
+
+const arbSplitMode = fc.constantFrom(
+  'EVENLY' as const,
+  'BY_SHARES' as const,
+  'BY_AMOUNT' as const,
+)
+
+/**
+ * Generate a list of unique participant IDs (2–8 participants).
+ */
+const arbParticipantIds = fc
+  .array(fc.uuid(), { minLength: 2, maxLength: 8 })
+  .map((ids) => Array.from(new Set(ids)))
+  .filter((ids) => ids.length >= 2)
+
+/**
+ * Generate paidFor entries for given participants and split mode.
+ */
+function arbPaidFor(
+  participantIds: string[],
+  splitMode: 'EVENLY' | 'BY_SHARES' | 'BY_AMOUNT',
+  total: number,
+): fc.Arbitrary<Array<{ user: { id: string; name: string }; shares: number }>> {
+  return fc
+    .shuffledSubarray(participantIds, {
+      minLength: 1,
+      maxLength: participantIds.length,
+    })
+    .chain((beneficiaryIds) => {
+      switch (splitMode) {
+        case 'EVENLY':
+          return fc.constant(
+            beneficiaryIds.map((id) => ({
+              user: { id, name: id },
+              shares: 1,
+            })),
+          )
+        case 'BY_SHARES':
+          return fc
+            .array(fc.integer({ min: 1, max: 100 }), {
+              minLength: beneficiaryIds.length,
+              maxLength: beneficiaryIds.length,
+            })
+            .map((shares) =>
+              beneficiaryIds.map((id, i) => ({
+                user: { id, name: id },
+                shares: shares[i],
+              })),
+            )
+        case 'BY_AMOUNT': {
+          const numBeneficiaries = beneficiaryIds.length
+          if (numBeneficiaries === 1) {
+            return fc.constant([
+              {
+                user: { id: beneficiaryIds[0], name: beneficiaryIds[0] },
+                shares: total,
+              },
+            ])
+          }
+          return fc
+            .array(
+              fc.integer({
+                min: 1,
+                max: Math.max(1, total - numBeneficiaries),
+              }),
+              {
+                minLength: numBeneficiaries - 1,
+                maxLength: numBeneficiaries - 1,
+              },
+            )
+            .map((shares) => {
+              const rawSum = shares.reduce((s, a) => s + a, 0)
+              const scaledShares = shares.map((a) =>
+                Math.max(1, Math.floor((a / rawSum) * (total - 1))),
+              )
+              const scaledSum = scaledShares.reduce((s, a) => s + a, 0)
+              const lastShare = total - scaledSum
+
+              if (lastShare <= 0) {
+                const fallback = beneficiaryIds.slice(0, -1).map(() => 1)
+                const fallbackLast = total - fallback.reduce((s, a) => s + a, 0)
+                return beneficiaryIds.map((id, i) => ({
+                  user: { id, name: id },
+                  shares: i < numBeneficiaries - 1 ? fallback[i] : fallbackLast,
+                }))
+              }
+
+              return beneficiaryIds.map((id, i) => ({
+                user: { id, name: id },
+                shares: i < numBeneficiaries - 1 ? scaledShares[i] : lastShare,
+              }))
+            })
+            .filter((paidFor) => paidFor.every((p) => p.shares > 0))
+        }
+      }
+    })
+}
+
+/**
+ * Generate a single-payer expense (pre-migration state).
+ * These expenses have a single paidById user and no payers entries.
+ */
+function arbSinglePayerExpense(
+  participantIds: string[],
+): fc.Arbitrary<{
+  total: number
+  splitMode: string
+  paidFor: any[]
+  payerId: string
+}> {
+  return fc.integer({ min: 1, max: 10_000_000 }).chain((total) =>
+    arbSplitMode.chain((splitMode) =>
+      arbPaidFor(participantIds, splitMode, total).chain((paidFor) =>
+        fc.constantFrom(...participantIds).map((payerId) => ({
+          total,
+          splitMode,
+          paidFor,
+          payerId,
+        })),
+      ),
+    ),
+  )
+}
+
+// --- Helpers ---
+
+/**
+ * Simulate pre-migration expense: payers array is empty,
+ * getBalances falls back to paidBy.id with full amount.
+ */
+function toLegacyExpense(exp: {
+  total: number
+  splitMode: string
+  paidFor: any[]
+  payerId: string
+}): Expense {
+  return {
+    amount: exp.total,
+    isReimbursement: false,
+    splitMode: exp.splitMode,
+    paidBy: { id: exp.payerId, name: exp.payerId },
+    paidFor: exp.paidFor,
+    payers: [],
+  } as unknown as Expense
+}
+
+/**
+ * Simulate post-migration expense: payers array has one entry
+ * with userId = paidById and amount = expense.amount.
+ * This is exactly what the migration does.
+ */
+function toMigratedExpense(exp: {
+  total: number
+  splitMode: string
+  paidFor: any[]
+  payerId: string
+}): Expense {
+  return {
+    amount: exp.total,
+    isReimbursement: false,
+    splitMode: exp.splitMode,
+    paidBy: { id: exp.payerId, name: exp.payerId },
+    paidFor: exp.paidFor,
+    payers: [
+      {
+        userId: exp.payerId,
+        amount: exp.total,
+        user: { id: exp.payerId, name: exp.payerId },
+      },
+    ],
+  } as Expense
+}
+
+// --- Tests ---
+
+describe('Multi-Payer Migration — Property-Based Tests', () => {
+  /**
+   * Property 6: Migration Correctness and Idempotence
+   *
+   * **Validates: Requirements 6.1, 6.3**
+   *
+   * For any set of existing expenses, the data migration SHALL create exactly one
+   * ExpensePaidBy row per expense (with userId = paidById and amount = expense.amount),
+   * and running the migration N times SHALL produce the same database state as running
+   * it once (no duplicate rows).
+   */
+  describe('Property 6: Migration Correctness and Idempotence', () => {
+    it('migration produces exactly one payer entry per expense with correct userId and amount', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc
+              .array(arbSinglePayerExpense(ids), {
+                minLength: 1,
+                maxLength: 10,
+              })
+              .map((exps) => ({ ids, exps })),
+          ),
+          ({ exps }) => {
+            // Simulate migration: for each expense, create one payer entry
+            for (const exp of exps) {
+              const migrated = toMigratedExpense(exp)
+
+              // Exactly one payer entry
+              expect(migrated.payers).toHaveLength(1)
+              // userId matches paidById
+              expect(migrated.payers![0].userId).toBe(exp.payerId)
+              // amount matches expense total
+              expect(migrated.payers![0].amount).toBe(exp.total)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('repeated migration produces identical state (idempotence)', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc
+              .array(arbSinglePayerExpense(ids), {
+                minLength: 1,
+                maxLength: 10,
+              })
+              .map((exps) => ({ ids, exps })),
+          ),
+          ({ exps }) => {
+            // Simulate running migration multiple times
+            // The migration uses ON CONFLICT DO NOTHING, so applying it N times
+            // should yield the same set of payer entries as applying it once.
+            const migrateOnce = exps.map(toMigratedExpense)
+            const migrateTwice = exps.map(toMigratedExpense)
+            const migrateThrice = exps.map(toMigratedExpense)
+
+            for (let i = 0; i < exps.length; i++) {
+              // All migrations produce identical payer arrays
+              expect(migrateOnce[i].payers).toEqual(migrateTwice[i].payers)
+              expect(migrateTwice[i].payers).toEqual(migrateThrice[i].payers)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+  })
+
+  /**
+   * Property 7: Migration Balance Preservation
+   *
+   * **Validates: Requirements 6.4**
+   *
+   * For any group, the net balance (paid − paidFor) for every participant SHALL be
+   * identical before and after the data migration.
+   */
+  describe('Property 7: Migration Balance Preservation', () => {
+    it('net balance for every participant is identical before and after migration', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc
+              .array(arbSinglePayerExpense(ids), {
+                minLength: 1,
+                maxLength: 10,
+              })
+              .map((exps) => ({ ids, exps })),
+          ),
+          ({ ids, exps }) => {
+            // Before migration: legacy path (payers empty, uses paidBy.id with full amount)
+            const legacyExpenses = exps.map(toLegacyExpense)
+            const balancesBefore = getBalances(legacyExpenses)
+
+            // After migration: payers array has one entry per expense
+            const migratedExpenses = exps.map(toMigratedExpense)
+            const balancesAfter = getBalances(migratedExpenses)
+
+            // Every participant's net balance (total = paid - paidFor) must be identical
+            const allParticipantIds = Array.from(
+              new Set([
+                ...ids,
+                ...Object.keys(balancesBefore),
+                ...Object.keys(balancesAfter),
+              ]),
+            )
+
+            for (const id of allParticipantIds) {
+              const before = balancesBefore[id] ?? {
+                paid: 0,
+                paidFor: 0,
+                total: 0,
+              }
+              const after = balancesAfter[id] ?? {
+                paid: 0,
+                paidFor: 0,
+                total: 0,
+              }
+
+              expect(after.paid).toBe(before.paid)
+              expect(after.paidFor).toBe(before.paidFor)
+              expect(after.total).toBe(before.total)
+            }
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('migration preserves balances for groups with mixed expense types', () => {
+      fc.assert(
+        fc.property(
+          arbParticipantIds.chain((ids) =>
+            fc
+              .array(arbSinglePayerExpense(ids), { minLength: 2, maxLength: 8 })
+              .map((exps) => ({ ids, exps })),
+          ),
+          ({ ids, exps }) => {
+            // Before migration: all expenses use legacy path
+            const legacyExpenses = exps.map(toLegacyExpense)
+            const balancesBefore = getBalances(legacyExpenses)
+
+            // After migration: all expenses have payers array populated
+            const migratedExpenses = exps.map(toMigratedExpense)
+            const balancesAfter = getBalances(migratedExpenses)
+
+            // Verify net positions are preserved (paid, paidFor, total)
+            const allParticipantIds = Array.from(
+              new Set([
+                ...ids,
+                ...Object.keys(balancesBefore),
+                ...Object.keys(balancesAfter),
+              ]),
+            )
+
+            // Sum of all totals should be zero (zero-sum invariant)
+            let sumBefore = 0
+            let sumAfter = 0
+
+            for (const id of allParticipantIds) {
+              const before = balancesBefore[id] ?? {
+                paid: 0,
+                paidFor: 0,
+                total: 0,
+              }
+              const after = balancesAfter[id] ?? {
+                paid: 0,
+                paidFor: 0,
+                total: 0,
+              }
+
+              // Individual balances preserved
+              expect(after.paid).toBe(before.paid)
+              expect(after.paidFor).toBe(before.paidFor)
+              expect(after.total).toBe(before.total)
+
+              sumBefore += before.total
+              sumAfter += after.total
+            }
+
+            // Zero-sum invariant holds both before and after
+            expect(sumBefore).toBe(sumAfter)
+          },
+        ),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+  })
+})

--- a/src/lib/__tests__/migration-multi-payer.property.test.ts
+++ b/src/lib/__tests__/migration-multi-payer.property.test.ts
@@ -117,9 +117,7 @@ function arbPaidFor(
  * Generate a single-payer expense (pre-migration state).
  * These expenses have a single paidById user and no payers entries.
  */
-function arbSinglePayerExpense(
-  participantIds: string[],
-): fc.Arbitrary<{
+function arbSinglePayerExpense(participantIds: string[]): fc.Arbitrary<{
   total: number
   splitMode: string
   paidFor: any[]

--- a/src/lib/__tests__/recurring-multi-payer.property.test.ts
+++ b/src/lib/__tests__/recurring-multi-payer.property.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Property-based tests for recurring expense multi-payer propagation.
+ *
+ * Feature: multi-payer-expenses, Property 16: Recurring Expense PaidBy Propagation
+ * Uses fast-check for property-based testing with minimum 100 iterations.
+ *
+ * **Validates: Requirements 12.1, 12.2**
+ */
+
+import fc from 'fast-check'
+
+const PBT_NUM_RUNS = 100
+
+// --- Types ---
+
+interface PayerEntry {
+  userId: string
+  amount: number
+}
+
+// --- Materialization Logic ---
+
+/**
+ * Simulates the recurring expense materialization logic from src/lib/api.ts.
+ * The createRecurringExpenses function copies payers from the source expense
+ * to the new instance via:
+ *
+ *   payers: {
+ *     createMany: {
+ *       data: currentExpenseRecord.payers.map((payer) => ({
+ *         userId: payer.userId,
+ *         amount: payer.amount,
+ *       })),
+ *     },
+ *   }
+ *
+ * This function replicates that copy logic in isolation.
+ */
+function materializePayers(sourcePayers: PayerEntry[]): PayerEntry[] {
+  return sourcePayers.map((payer) => ({
+    userId: payer.userId,
+    amount: payer.amount,
+  }))
+}
+
+// --- Generators ---
+
+/**
+ * Generate a list of unique user IDs (1–5 payers).
+ */
+const arbUniqueUserIds = fc
+  .array(fc.uuid(), { minLength: 1, maxLength: 5 })
+  .map((ids) => Array.from(new Set(ids)))
+  .filter((ids) => ids.length >= 1)
+
+/**
+ * Generate a valid payer set: 1–5 payers whose amounts sum to a positive total.
+ * Amounts are positive integers in minor currency units.
+ */
+function arbPayerSet(): fc.Arbitrary<{ payers: PayerEntry[]; total: number }> {
+  return arbUniqueUserIds.chain((userIds) => {
+    const numPayers = userIds.length
+
+    if (numPayers === 1) {
+      return fc.integer({ min: 1, max: 10_000_000 }).map((total) => ({
+        payers: [{ userId: userIds[0], amount: total }],
+        total,
+      }))
+    }
+
+    // Generate a total and distribute it among payers
+    return fc.integer({ min: numPayers, max: 10_000_000 }).chain((total) => {
+      // Generate N-1 amounts that leave a positive remainder for the last payer
+      return fc
+        .array(fc.integer({ min: 1, max: Math.max(1, total - numPayers) }), {
+          minLength: numPayers - 1,
+          maxLength: numPayers - 1,
+        })
+        .map((rawAmounts) => {
+          const rawSum = rawAmounts.reduce((s, a) => s + a, 0)
+          // Scale amounts so they sum to less than total, leaving at least 1 for last payer
+          const scaledAmounts = rawAmounts.map((a) =>
+            Math.max(1, Math.floor((a / rawSum) * (total - 1))),
+          )
+          const scaledSum = scaledAmounts.reduce((s, a) => s + a, 0)
+          const lastAmount = total - scaledSum
+
+          if (lastAmount <= 0) {
+            // Fallback: give 1 to each and remainder to last
+            const fallbackAmounts = userIds.slice(0, -1).map(() => 1)
+            const fallbackLast =
+              total - fallbackAmounts.reduce((s, a) => s + a, 0)
+            return {
+              payers: userIds.map((id, i) => ({
+                userId: id,
+                amount: i < numPayers - 1 ? fallbackAmounts[i] : fallbackLast,
+              })),
+              total,
+            }
+          }
+
+          return {
+            payers: userIds.map((id, i) => ({
+              userId: id,
+              amount: i < numPayers - 1 ? scaledAmounts[i] : lastAmount,
+            })),
+            total,
+          }
+        })
+        .filter(({ payers }) => payers.every((p) => p.amount > 0))
+    })
+  })
+}
+
+// --- Tests ---
+
+describe('Recurring Expense Multi-Payer — Property-Based Tests', () => {
+  /**
+   * Property 16: Recurring Expense PaidBy Propagation
+   *
+   * **Validates: Requirements 12.1, 12.2**
+   *
+   * For any recurring expense with N payers, each materialized instance SHALL
+   * contain exactly N ExpensePaidBy rows with the same userIds and amounts as
+   * the source expense at the time of materialization.
+   */
+  describe('Property 16: Recurring Expense PaidBy Propagation', () => {
+    it('materialized instance has identical payer count as source', () => {
+      fc.assert(
+        fc.property(arbPayerSet(), ({ payers }) => {
+          const materialized = materializePayers(payers)
+          expect(materialized).toHaveLength(payers.length)
+        }),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('materialized instance has identical userIds as source', () => {
+      fc.assert(
+        fc.property(arbPayerSet(), ({ payers }) => {
+          const materialized = materializePayers(payers)
+          const sourceUserIds = payers.map((p) => p.userId).sort()
+          const materializedUserIds = materialized.map((p) => p.userId).sort()
+          expect(materializedUserIds).toEqual(sourceUserIds)
+        }),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('materialized instance has identical amounts as source', () => {
+      fc.assert(
+        fc.property(arbPayerSet(), ({ payers }) => {
+          const materialized = materializePayers(payers)
+          const sourceAmounts = payers
+            .map((p) => p.amount)
+            .sort((a, b) => a - b)
+          const materializedAmounts = materialized
+            .map((p) => p.amount)
+            .sort((a, b) => a - b)
+          expect(materializedAmounts).toEqual(sourceAmounts)
+        }),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('materialized instance payers match source payers exactly (userId-amount pairs)', () => {
+      fc.assert(
+        fc.property(arbPayerSet(), ({ payers }) => {
+          const materialized = materializePayers(payers)
+
+          // Each source payer must have a corresponding materialized payer
+          // with the same userId and amount
+          const sortByUserId = (a: PayerEntry, b: PayerEntry) =>
+            a.userId.localeCompare(b.userId)
+
+          const sortedSource = [...payers].sort(sortByUserId)
+          const sortedMaterialized = [...materialized].sort(sortByUserId)
+
+          expect(sortedMaterialized).toEqual(sortedSource)
+        }),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('materialized payers are independent copies (no shared references)', () => {
+      fc.assert(
+        fc.property(arbPayerSet(), ({ payers }) => {
+          const materialized = materializePayers(payers)
+
+          // Mutating materialized entries should not affect source
+          for (const entry of materialized) {
+            entry.amount = 0
+            entry.userId = 'mutated'
+          }
+
+          // Source should remain unchanged
+          for (const payer of payers) {
+            expect(payer.userId).not.toBe('mutated')
+            expect(payer.amount).toBeGreaterThan(0)
+          }
+        }),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+
+    it('sum of materialized payer amounts equals source expense total', () => {
+      fc.assert(
+        fc.property(arbPayerSet(), ({ payers, total }) => {
+          const materialized = materializePayers(payers)
+          const materializedSum = materialized.reduce((s, p) => s + p.amount, 0)
+          expect(materializedSum).toBe(total)
+        }),
+        { numRuns: PBT_NUM_RUNS },
+      )
+    })
+  })
+})

--- a/src/lib/__tests__/splitwise-import-multi-payer.property.test.ts
+++ b/src/lib/__tests__/splitwise-import-multi-payer.property.test.ts
@@ -52,9 +52,7 @@ const arbCostDollars = fc
  * K is between 1 and the total number of users.
  * The amounts don't need to sum to cost — the importer adjusts the last payer.
  */
-function arbPayerAmounts(
-  userNames: string[],
-): fc.Arbitrary<{
+function arbPayerAmounts(userNames: string[]): fc.Arbitrary<{
   payerAmounts: Map<string, number>
   nonPayerNames: string[]
 }> {

--- a/src/lib/__tests__/splitwise-import-multi-payer.property.test.ts
+++ b/src/lib/__tests__/splitwise-import-multi-payer.property.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Property-based tests for Splitwise multi-payer import.
+ *
+ * Feature: multi-payer-expenses, Property 8: Splitwise Multi-Payer Import
+ * Uses fast-check for property-based testing with minimum 100 iterations.
+ *
+ * **Validates: Requirements 7.1, 7.3, 7.4**
+ */
+
+import { prisma } from '@/lib/prisma'
+import { parseSplitwiseCSV } from '@/lib/splitwise-import'
+import fc from 'fast-check'
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    group: {
+      findUnique: jest.fn(),
+    },
+    category: {
+      findMany: jest.fn(),
+    },
+  },
+}))
+
+const mockGroupFindUnique = prisma.group.findUnique as jest.Mock
+const mockCategoryFindMany = prisma.category.findMany as jest.Mock
+
+// --- Constants ---
+
+const PBT_NUM_RUNS = 100
+
+// --- Generators ---
+
+/**
+ * Generate K unique user names for CSV columns (2–6 users).
+ * Names are simple alphabetic strings to avoid CSV parsing issues.
+ */
+const arbUserNames = fc
+  .array(fc.stringMatching(/^[A-Z][a-z]{2,8}$/), { minLength: 2, maxLength: 6 })
+  .map((names) => Array.from(new Set(names)))
+  .filter((names) => names.length >= 2)
+
+/**
+ * Generate a positive cost value in dollars (0.01–9999.99).
+ */
+const arbCostDollars = fc
+  .integer({ min: 1, max: 999999 })
+  .map((cents) => cents / 100)
+
+/**
+ * Generate K positive payer amounts (in dollars) for a subset of users.
+ * K is between 1 and the total number of users.
+ * The amounts don't need to sum to cost — the importer adjusts the last payer.
+ */
+function arbPayerAmounts(
+  userNames: string[],
+): fc.Arbitrary<{
+  payerAmounts: Map<string, number>
+  nonPayerNames: string[]
+}> {
+  const numUsers = userNames.length
+  return fc.integer({ min: 1, max: numUsers }).chain((k) =>
+    fc
+      .shuffledSubarray(userNames, { minLength: k, maxLength: k })
+      .chain((payerNames) =>
+        fc
+          .array(fc.integer({ min: 1, max: 100000 }), {
+            minLength: k,
+            maxLength: k,
+          })
+          .map((amountCents) => {
+            const payerAmounts = new Map<string, number>()
+            payerNames.forEach((name, i) => {
+              // Convert cents to dollars with 2 decimal places
+              payerAmounts.set(name, amountCents[i] / 100)
+            })
+            const nonPayerNames = userNames.filter(
+              (name) => !payerNames.includes(name),
+            )
+            return { payerAmounts, nonPayerNames }
+          }),
+      ),
+  )
+}
+
+/**
+ * Build a Splitwise CSV string from generated data.
+ */
+function buildCsv(
+  userNames: string[],
+  cost: number,
+  payerAmounts: Map<string, number>,
+  nonPayerNames: string[],
+): string {
+  const headers = [
+    'Date',
+    'Description',
+    'Category',
+    'Cost',
+    'Currency',
+    ...userNames,
+  ]
+  const headerLine = headers.join(',')
+
+  // Build data row: payers get their positive amount, non-payers get a negative value
+  const userValues = userNames.map((name) => {
+    const payerAmount = payerAmounts.get(name)
+    if (payerAmount !== undefined) {
+      return payerAmount.toFixed(2)
+    }
+    // Non-payer: give them a negative amount (they owe money)
+    return '-5.00'
+  })
+
+  const dataLine = [
+    '2026-01-15',
+    'Test Expense',
+    'General',
+    cost.toFixed(2),
+    'EUR',
+    ...userValues,
+  ].join(',')
+
+  return `${headerLine}\n${dataLine}`
+}
+
+// --- Tests ---
+
+describe('Splitwise Multi-Payer Import — Property-Based Tests', () => {
+  beforeEach(() => {
+    mockCategoryFindMany.mockResolvedValue([
+      { id: 1, name: 'General', grouping: 'Uncategorized' },
+    ])
+  })
+
+  /**
+   * Property 8: Splitwise Multi-Payer Import
+   *
+   * **Validates: Requirements 7.1, 7.3, 7.4**
+   *
+   * For any Splitwise CSV row with K positive user-column values (K ≥ 1),
+   * the importer SHALL produce exactly K payer entries whose amounts equal
+   * the corresponding positive column values (converted to minor units) and
+   * whose sum equals the row's cost exactly (with rounding remainder assigned
+   * to the last payer).
+   */
+  it('K positive columns → K payers; sum equals row cost exactly', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbUserNames.chain((userNames) =>
+          arbCostDollars.chain((cost) =>
+            arbPayerAmounts(userNames).map(
+              ({ payerAmounts, nonPayerNames }) => ({
+                userNames,
+                cost,
+                payerAmounts,
+                nonPayerNames,
+              }),
+            ),
+          ),
+        ),
+        async ({ userNames, cost, payerAmounts, nonPayerNames }) => {
+          // Setup mock group with members matching user names
+          const csvNameToUserId: Record<string, string> = {}
+          const memberships = userNames.map((name) => {
+            const userId = `user-${name.toLowerCase()}`
+            csvNameToUserId[name] = userId
+            return { user: { id: userId, name } }
+          })
+
+          mockGroupFindUnique.mockResolvedValue({
+            id: 'group-1',
+            memberships,
+          })
+
+          const csv = buildCsv(userNames, cost, payerAmounts, nonPayerNames)
+
+          const expenses = await parseSplitwiseCSV(csv, 'group-1', {
+            csvNameToUserId,
+          })
+
+          expect(expenses).toHaveLength(1)
+
+          const expense = expenses[0]
+          const paidBy = expense.paidBy as Array<{
+            participant: string
+            amount: number
+          }>
+          const K = payerAmounts.size
+
+          // Assert: number of payer entries equals K (Requirement 7.1)
+          expect(paidBy).toHaveLength(K)
+
+          // Assert: sum of payer amounts equals row cost exactly (Requirement 7.4)
+          const costInCents = Math.round(cost * 100)
+          const payerSum = paidBy.reduce((sum, entry) => sum + entry.amount, 0)
+          expect(payerSum).toBe(costInCents)
+
+          // Assert: each payer corresponds to a user with a positive column value (Requirement 7.3)
+          // The paidBy order follows the CSV column order, so we verify by participant ID
+          const resultPayerMap = new Map(
+            paidBy.map((entry) => [entry.participant, entry.amount]),
+          )
+
+          // All payers in result must correspond to users with positive columns
+          for (const [participant] of Array.from(resultPayerMap)) {
+            const matchingName = userNames.find(
+              (name) => csvNameToUserId[name] === participant,
+            )
+            expect(matchingName).toBeDefined()
+            expect(payerAmounts.has(matchingName!)).toBe(true)
+          }
+
+          // All but the last payer should have their exact column value in minor units.
+          // The last payer (in CSV column order) absorbs rounding (Requirement 7.4).
+          // The sum invariant above guarantees correctness overall.
+        },
+      ),
+      { numRuns: PBT_NUM_RUNS },
+    )
+  })
+})

--- a/src/lib/__tests__/stats.property.test.ts
+++ b/src/lib/__tests__/stats.property.test.ts
@@ -322,6 +322,7 @@ describe('Enhanced Stats Dashboard — Property-Based Tests', () => {
               isReimbursement: false,
               paidBy: { id: ids[0], name: 'Test' },
               paidFor: [{ user: { id: ids[0], name: 'Test' }, shares: 1 }],
+              payers: [],
               splitMode: 'EVENLY' as const,
               title: 'Test expense',
               recurrenceRule: null,

--- a/src/lib/__tests__/validation-multi-payer.property.test.ts
+++ b/src/lib/__tests__/validation-multi-payer.property.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Property-based tests for multi-payer validation.
+ *
+ * Feature: multi-payer-expenses
+ * Uses fast-check for property-based testing with minimum 100 iterations.
+ */
+
+import { TRPCError } from '@trpc/server'
+import fc from 'fast-check'
+import { createExpense } from '../api'
+import type { ExpenseFormValues } from '../schemas'
+
+// Mock nanoid
+jest.mock('nanoid', () => ({
+  nanoid: () => 'mocked-nanoid',
+}))
+
+// Mock prisma
+const mockGroupFindUnique = jest.fn()
+const mockExpenseCreate = jest.fn()
+const mockActivityCreate = jest.fn()
+const mockRecurringExpenseLinkFindMany = jest.fn()
+
+jest.mock('../prisma', () => ({
+  prisma: {
+    group: {
+      findUnique: (...args: unknown[]) => mockGroupFindUnique(...args),
+    },
+    expense: {
+      create: (...args: unknown[]) => mockExpenseCreate(...args),
+    },
+    activity: {
+      create: (...args: unknown[]) => mockActivityCreate(...args),
+    },
+    recurringExpenseLink: {
+      findMany: (...args: unknown[]) =>
+        mockRecurringExpenseLinkFindMany(...args),
+    },
+    expenseCategoryMapping: {
+      upsert: jest.fn(),
+    },
+  },
+}))
+
+// Mock rrule to avoid import issues
+jest.mock('rrule', () => ({
+  RRule: class {
+    static fromString() {
+      return { after: () => new Date() }
+    }
+  },
+}))
+
+// Mock payments module
+jest.mock('../payments', () => ({
+  assertPaymentEditable: jest.fn(),
+}))
+
+// --- Constants ---
+
+const PBT_NUM_RUNS = 100
+const GROUP_ID = 'group-1'
+
+// --- Generators ---
+
+/**
+ * Generate a list of unique participant IDs (2–8 participants).
+ */
+const arbParticipantIds = fc
+  .array(fc.uuid(), { minLength: 2, maxLength: 8 })
+  .map((ids) => Array.from(new Set(ids)))
+  .filter((ids) => ids.length >= 2)
+
+/**
+ * Generate a paidBy array that contains at least one duplicate userId.
+ * Strategy: pick participants, then force at least one to appear twice.
+ */
+function arbDuplicatePaidBy(
+  participantIds: string[],
+  total: number,
+): fc.Arbitrary<Array<{ participant: string; amount: number }>> {
+  return fc
+    .integer({ min: 0, max: participantIds.length - 1 })
+    .chain((dupIndex) => {
+      const duplicateId = participantIds[dupIndex]
+      // Create an array with at least 2 entries for the same participant
+      const numExtraEntries = Math.max(
+        0,
+        Math.min(participantIds.length - 1, 3),
+      )
+      return fc
+        .integer({ min: 2, max: Math.max(2, numExtraEntries + 1) })
+        .chain((numEntries) => {
+          // Distribute the total across numEntries entries, ensuring all > 0
+          return arbPositiveAmountsSummingTo(total, numEntries).map(
+            (amounts) => {
+              const entries: Array<{ participant: string; amount: number }> = []
+              // First entry is the duplicate
+              entries.push({ participant: duplicateId, amount: amounts[0] })
+              // Fill middle entries with other participants or duplicateId
+              for (let i = 1; i < numEntries - 1; i++) {
+                // Use a different participant if available
+                const otherId =
+                  participantIds[(dupIndex + i) % participantIds.length]
+                entries.push({ participant: otherId, amount: amounts[i] })
+              }
+              // Last entry is always the duplicate to guarantee duplication
+              entries.push({
+                participant: duplicateId,
+                amount: amounts[numEntries - 1],
+              })
+              return entries
+            },
+          )
+        })
+    })
+}
+
+/**
+ * Generate N positive integers that sum exactly to `total`.
+ */
+function arbPositiveAmountsSummingTo(
+  total: number,
+  n: number,
+): fc.Arbitrary<number[]> {
+  if (n === 1) return fc.constant([total])
+  // Generate n-1 cut points in [1, total-1], then derive amounts
+  return fc
+    .array(fc.integer({ min: 1, max: total - 1 }), {
+      minLength: n - 1,
+      maxLength: n - 1,
+    })
+    .map((cuts) => {
+      const sorted = [...cuts, 0, total].sort((a, b) => a - b)
+      const amounts: number[] = []
+      for (let i = 1; i < sorted.length; i++) {
+        amounts.push(sorted[i] - sorted[i - 1])
+      }
+      return amounts
+    })
+    .filter((amounts) => amounts.every((a) => a > 0))
+}
+
+function makeExpenseFormValues(
+  overrides: Partial<ExpenseFormValues> = {},
+): ExpenseFormValues {
+  return {
+    expenseDate: new Date('2024-06-15'),
+    title: 'Test Expense',
+    category: 1,
+    amount: 10000,
+    paidBy: [{ participant: 'default-payer', amount: 10000 }],
+    paidFor: [
+      { participant: 'p1', shares: 1 },
+      { participant: 'p2', shares: 1 },
+    ],
+    splitMode: 'EVENLY',
+    isReimbursement: false,
+    documents: [],
+    notes: '',
+    saveDefaultSplittingOptions: false,
+    recurrenceRule: 'NONE',
+    ...overrides,
+  } as ExpenseFormValues
+}
+
+// --- Property Tests ---
+
+describe('Feature: multi-payer-expenses, Property 17: No Duplicate Payer Participants', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockActivityCreate.mockResolvedValue({ id: 'activity-1', changes: [] })
+    mockRecurringExpenseLinkFindMany.mockResolvedValue([])
+    mockExpenseCreate.mockResolvedValue({ id: 'expense-1' })
+  })
+
+  /**
+   * **Validates: Requirements 2.5**
+   *
+   * For any expense submission containing duplicate userId entries in paidBy,
+   * the API SHALL reject with a BAD_REQUEST TRPCError containing
+   * "Duplicate payer: {userId}".
+   */
+  it('rejects paidBy arrays with duplicate userId entries', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbParticipantIds,
+        fc.integer({ min: 200, max: 1_000_000 }),
+        async (participantIds, total) => {
+          // Set up group with these participants
+          mockGroupFindUnique.mockResolvedValue({
+            id: GROUP_ID,
+            memberships: participantIds.map((id) => ({
+              user: { id, name: id, email: `${id}@test.com` },
+            })),
+            participants: participantIds.map((id) => ({
+              id,
+              name: id,
+              email: `${id}@test.com`,
+            })),
+          })
+
+          // Generate paidBy with at least one duplicate
+          const paidBy = await fc.sample(
+            arbDuplicatePaidBy(participantIds, total),
+            1,
+          )[0]
+
+          // Build paidFor using first 2 participants
+          const paidFor = participantIds.slice(0, 2).map((id) => ({
+            participant: id,
+            shares: 1,
+          }))
+
+          const values = makeExpenseFormValues({
+            amount: total,
+            paidBy,
+            paidFor,
+          })
+
+          try {
+            await createExpense(values, GROUP_ID)
+            // Should not reach here
+            throw new Error('Expected TRPCError but createExpense succeeded')
+          } catch (error) {
+            expect(error).toBeInstanceOf(TRPCError)
+            const trpcError = error as TRPCError
+            expect(trpcError.code).toBe('BAD_REQUEST')
+            expect(trpcError.message).toMatch(/^Duplicate payer: /)
+          }
+        },
+      ),
+      { numRuns: PBT_NUM_RUNS },
+    )
+  }, 30_000)
+})

--- a/src/lib/activity-diff.property.test.ts
+++ b/src/lib/activity-diff.property.test.ts
@@ -13,7 +13,6 @@ const TRACKED_SCALAR_FIELDS = [
   'amount',
   'expenseDate',
   'category',
-  'paidBy',
   'splitMode',
   'isReimbursement',
   'notes',
@@ -67,13 +66,19 @@ const existingExpenseArb = fc.record({
   paidFor: existingPaidForArb,
 })
 
+// Arbitrary for a paidBy entry in updated shape (multi-payer)
+const paidByEntryArb = fc.record({
+  participant: participantIdArb,
+  amount: fc.integer({ min: 1, max: 1_000_000 }),
+})
+
 // Arbitrary for an updated expense object
 const updatedExpenseArb = fc.record({
   title: fc.string({ minLength: 1, maxLength: 50 }),
   amount: fc.integer({ min: 0, max: 1_000_000 }),
   expenseDate: dateArb,
   category: fc.integer({ min: 0, max: 100 }),
-  paidBy: participantIdArb,
+  paidBy: fc.array(paidByEntryArb, { minLength: 1, maxLength: 5 }),
   splitMode: fc.constantFrom(
     'EVENLY',
     'BY_SHARES',
@@ -119,7 +124,7 @@ function computeExpectedChangedFields(
     amount: number
     expenseDate: Date
     category: number
-    paidBy: string
+    paidBy: Array<{ participant: string; amount: number }>
     splitMode: string
     isReimbursement: boolean
     notes: string | null | undefined
@@ -143,7 +148,6 @@ function computeExpectedChangedFields(
         oldVal: existing.categoryId,
         newVal: updated.category,
       },
-      { field: 'paidBy', oldVal: existing.paidById, newVal: updated.paidBy },
       {
         field: 'splitMode',
         oldVal: existing.splitMode,
@@ -170,6 +174,22 @@ function computeExpectedChangedFields(
     if (serialize(oldVal) !== serialize(newVal)) {
       changedFields.add(field)
     }
+  }
+
+  // paidBy comparison (multi-payer: compare sorted {userId, amount} arrays)
+  const oldPayers = [{ userId: existing.paidById, amount: existing.amount }]
+  const newPayers = updated.paidBy.map((e) => ({
+    userId: e.participant,
+    amount: e.amount,
+  }))
+  const sortedOld = [...oldPayers].sort((a, b) =>
+    a.userId.localeCompare(b.userId),
+  )
+  const sortedNew = [...newPayers].sort((a, b) =>
+    a.userId.localeCompare(b.userId),
+  )
+  if (JSON.stringify(sortedOld) !== JSON.stringify(sortedNew)) {
+    changedFields.add('paidBy')
   }
 
   // paidFor comparison

--- a/src/lib/activity-diff.test.ts
+++ b/src/lib/activity-diff.test.ts
@@ -12,6 +12,7 @@ describe('computeExpenseChanges', () => {
     notes: null,
     recurrenceRule: null,
     paidFor: [{ userId: 'participant-1' }, { userId: 'participant-2' }],
+    payers: [{ userId: 'participant-1', amount: 5000 }],
   }
 
   const baseUpdated = {
@@ -19,7 +20,7 @@ describe('computeExpenseChanges', () => {
     amount: 5000,
     expenseDate: new Date('2024-06-15T12:00:00.000Z'),
     category: 1,
-    paidBy: 'participant-1',
+    paidBy: [{ participant: 'participant-1', amount: 5000 }],
     splitMode: 'EVENLY',
     isReimbursement: false,
     notes: null,
@@ -126,6 +127,183 @@ describe('computeExpenseChanges', () => {
       expect(changedFields).not.toContain('recurrenceRule')
       expect(changedFields).not.toContain('paidFor')
     })
+  })
+})
+
+describe('computeExpenseChanges — paidBy changes', () => {
+  const baseExpense = {
+    title: 'Dinner',
+    amount: 5000,
+    expenseDate: new Date('2024-06-15T12:00:00.000Z'),
+    categoryId: 1,
+    paidById: 'participant-1',
+    splitMode: 'EVENLY',
+    isReimbursement: false,
+    notes: null,
+    recurrenceRule: null,
+    paidFor: [{ userId: 'participant-1' }, { userId: 'participant-2' }],
+    payers: [{ userId: 'participant-1', amount: 5000 }],
+  }
+
+  const baseUpdated = {
+    title: 'Dinner',
+    amount: 5000,
+    expenseDate: new Date('2024-06-15T12:00:00.000Z'),
+    category: 1,
+    paidBy: [{ participant: 'participant-1', amount: 5000 }],
+    splitMode: 'EVENLY',
+    isReimbursement: false,
+    notes: null,
+    recurrenceRule: null,
+    paidFor: [
+      { participant: 'participant-1' },
+      { participant: 'participant-2' },
+    ],
+  }
+
+  it('generates a paidBy change when a second payer is added', () => {
+    const updated = {
+      ...baseUpdated,
+      paidBy: [
+        { participant: 'participant-1', amount: 3000 },
+        { participant: 'participant-2', amount: 2000 },
+      ],
+    }
+    const changes = computeExpenseChanges(baseExpense, updated)
+    const paidByChange = changes.find((c) => c.field === 'paidBy')
+    expect(paidByChange).toBeDefined()
+    expect(paidByChange!.oldValue).toBe(
+      JSON.stringify([{ userId: 'participant-1', amount: 5000 }]),
+    )
+    expect(paidByChange!.newValue).toBe(
+      JSON.stringify([
+        { userId: 'participant-1', amount: 3000 },
+        { userId: 'participant-2', amount: 2000 },
+      ]),
+    )
+  })
+
+  it('generates a paidBy change when payer amounts change', () => {
+    const existing = {
+      ...baseExpense,
+      payers: [
+        { userId: 'participant-1', amount: 3000 },
+        { userId: 'participant-2', amount: 2000 },
+      ],
+    }
+    const updated = {
+      ...baseUpdated,
+      paidBy: [
+        { participant: 'participant-1', amount: 4000 },
+        { participant: 'participant-2', amount: 1000 },
+      ],
+    }
+    const changes = computeExpenseChanges(existing, updated)
+    const paidByChange = changes.find((c) => c.field === 'paidBy')
+    expect(paidByChange).toBeDefined()
+    expect(paidByChange!.oldValue).toBe(
+      JSON.stringify([
+        { userId: 'participant-1', amount: 3000 },
+        { userId: 'participant-2', amount: 2000 },
+      ]),
+    )
+    expect(paidByChange!.newValue).toBe(
+      JSON.stringify([
+        { userId: 'participant-1', amount: 4000 },
+        { userId: 'participant-2', amount: 1000 },
+      ]),
+    )
+  })
+
+  it('does not generate a paidBy change when payers and amounts are identical', () => {
+    const existing = {
+      ...baseExpense,
+      payers: [
+        { userId: 'participant-1', amount: 3000 },
+        { userId: 'participant-2', amount: 2000 },
+      ],
+    }
+    const updated = {
+      ...baseUpdated,
+      paidBy: [
+        { participant: 'participant-1', amount: 3000 },
+        { participant: 'participant-2', amount: 2000 },
+      ],
+    }
+    const changes = computeExpenseChanges(existing, updated)
+    const paidByChange = changes.find((c) => c.field === 'paidBy')
+    expect(paidByChange).toBeUndefined()
+  })
+
+  it('does not generate a paidBy change when payers are identical but in different order', () => {
+    const existing = {
+      ...baseExpense,
+      payers: [
+        { userId: 'participant-2', amount: 2000 },
+        { userId: 'participant-1', amount: 3000 },
+      ],
+    }
+    const updated = {
+      ...baseUpdated,
+      paidBy: [
+        { participant: 'participant-1', amount: 3000 },
+        { participant: 'participant-2', amount: 2000 },
+      ],
+    }
+    const changes = computeExpenseChanges(existing, updated)
+    const paidByChange = changes.find((c) => c.field === 'paidBy')
+    expect(paidByChange).toBeUndefined()
+  })
+
+  it('records initial payer set on creation (fallback from paidById when no payers array)', () => {
+    const existing = {
+      ...baseExpense,
+      payers: undefined as unknown as Array<{
+        userId: string
+        amount: number
+      }>,
+    }
+    const updated = {
+      ...baseUpdated,
+      paidBy: [
+        { participant: 'participant-1', amount: 3000 },
+        { participant: 'participant-2', amount: 2000 },
+      ],
+    }
+    const changes = computeExpenseChanges(existing, updated)
+    const paidByChange = changes.find((c) => c.field === 'paidBy')
+    expect(paidByChange).toBeDefined()
+    // Fallback: old state derived from paidById + full amount
+    expect(paidByChange!.oldValue).toBe(
+      JSON.stringify([{ userId: 'participant-1', amount: 5000 }]),
+    )
+    expect(paidByChange!.newValue).toBe(
+      JSON.stringify([
+        { userId: 'participant-1', amount: 3000 },
+        { userId: 'participant-2', amount: 2000 },
+      ]),
+    )
+  })
+
+  it('records initial payer set on creation (empty payers array falls back to paidById)', () => {
+    const existing = {
+      ...baseExpense,
+      payers: [] as Array<{ userId: string; amount: number }>,
+    }
+    const updated = {
+      ...baseUpdated,
+      paidBy: [
+        { participant: 'participant-1', amount: 3000 },
+        { participant: 'participant-2', amount: 2000 },
+      ],
+    }
+    const changes = computeExpenseChanges(existing, updated)
+    const paidByChange = changes.find((c) => c.field === 'paidBy')
+    expect(paidByChange).toBeDefined()
+    // Fallback: old state derived from paidById + full amount
+    expect(paidByChange!.oldValue).toBe(
+      JSON.stringify([{ userId: 'participant-1', amount: 5000 }]),
+    )
   })
 })
 

--- a/src/lib/activity-diff.ts
+++ b/src/lib/activity-diff.ts
@@ -78,6 +78,20 @@ export function computeGroupChanges(
 }
 
 /**
+ * Serializes payer state to a canonical JSON string for comparison.
+ * Sorts by userId to ensure order-independent comparison.
+ * Returns a JSON array of `{userId, amount}` objects.
+ */
+export function serializePayers(
+  payers: Array<{ userId: string; amount: number }>,
+): string {
+  const sorted = [...payers].sort((a, b) => a.userId.localeCompare(b.userId))
+  return JSON.stringify(
+    sorted.map(({ userId, amount }) => ({ userId, amount })),
+  )
+}
+
+/**
  * Computes field-level differences between an existing expense (from DB)
  * and updated form values being submitted.
  */
@@ -93,13 +107,14 @@ export function computeExpenseChanges(
     notes?: string | null
     recurrenceRule?: string | null
     paidFor: Array<{ userId: string }>
+    payers?: Array<{ userId: string; amount: number }>
   },
   updated: {
     title: string
     amount: number
     expenseDate: Date
     category: number
-    paidBy: string
+    paidBy: Array<{ participant: string; amount: number }>
     splitMode: string
     isReimbursement: boolean
     notes?: string | null
@@ -126,7 +141,6 @@ export function computeExpenseChanges(
       oldVal: existing.categoryId,
       newVal: updated.category,
     },
-    { field: 'paidBy', oldVal: existing.paidById, newVal: updated.paidBy },
     {
       field: 'splitMode',
       oldVal: existing.splitMode,
@@ -160,6 +174,31 @@ export function computeExpenseChanges(
         newValue: newSerialized,
       })
     }
+  }
+
+  // Track paidBy changes (multi-payer support)
+  // Build the old payer state from existing.payers (preferred) or fall back to paidById + amount
+  const oldPayers: Array<{ userId: string; amount: number }> =
+    existing.payers && existing.payers.length > 0
+      ? existing.payers
+      : [{ userId: existing.paidById, amount: existing.amount }]
+
+  // Build the new payer state from updated.paidBy array
+  const newPayers: Array<{ userId: string; amount: number }> =
+    updated.paidBy.map((entry) => ({
+      userId: entry.participant,
+      amount: entry.amount,
+    }))
+
+  const oldPayersSerialized = serializePayers(oldPayers)
+  const newPayersSerialized = serializePayers(newPayers)
+
+  if (oldPayersSerialized !== newPayersSerialized) {
+    changes.push({
+      field: 'paidBy',
+      oldValue: oldPayersSerialized,
+      newValue: newPayersSerialized,
+    })
   }
 
   // Track paidFor changes (participants involved in split)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,7 @@ import {
   FieldChange,
   computeExpenseChanges,
   computeGroupChanges,
+  serializePayers,
 } from '@/lib/activity-diff'
 import { isPaymentCategory } from '@/lib/categories'
 import { upsertCategoryMapping } from '@/lib/category-mapping'
@@ -54,12 +55,41 @@ export async function createExpense(
 
   const memberIds = new Set(group.participants.map((p) => p.id))
 
-  if (!memberIds.has(expenseFormValues.paidBy)) {
+  // Validate all payer participant IDs are group members
+  for (const payer of expenseFormValues.paidBy) {
+    if (!memberIds.has(payer.participant)) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `User ${payer.participant} is not a group member`,
+      })
+    }
+  }
+
+  // Validate no duplicate userIds in paidBy
+  const payerUserIds = expenseFormValues.paidBy.map((p) => p.participant)
+  const uniquePayerIds = new Set(payerUserIds)
+  if (uniquePayerIds.size !== payerUserIds.length) {
+    const duplicate = payerUserIds.find(
+      (id, idx) => payerUserIds.indexOf(id) !== idx,
+    )
     throw new TRPCError({
       code: 'BAD_REQUEST',
-      message: 'paidBy user is not a group member',
+      message: `Duplicate payer: ${duplicate}`,
     })
   }
+
+  // Validate sum of payer amounts equals expense total
+  const payerAmountSum = expenseFormValues.paidBy.reduce(
+    (sum, entry) => sum + entry.amount,
+    0,
+  )
+  if (payerAmountSum !== expenseFormValues.amount) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Payer amounts must sum to expense total',
+    })
+  }
+
   for (const pf of expenseFormValues.paidFor) {
     if (!memberIds.has(pf.participant)) {
       throw new TRPCError({
@@ -77,7 +107,16 @@ export async function createExpense(
       oldValue: null,
       newValue: String(expenseFormValues.amount),
     },
-    { field: 'paidBy', oldValue: null, newValue: expenseFormValues.paidBy },
+    {
+      field: 'paidBy',
+      oldValue: null,
+      newValue: serializePayers(
+        expenseFormValues.paidBy.map((entry) => ({
+          userId: entry.participant,
+          amount: entry.amount,
+        })),
+      ),
+    },
   ]
 
   await logActivity(groupId, ActivityType.CREATE_EXPENSE, {
@@ -95,6 +134,9 @@ export async function createExpense(
     groupId,
   )
 
+  // Set deprecated paidById to first payer's ID
+  const paidById = expenseFormValues.paidBy[0].participant
+
   return prisma.expense.create({
     data: {
       id: expenseId,
@@ -106,7 +148,7 @@ export async function createExpense(
       originalCurrency: expenseFormValues.originalCurrency || null,
       conversionRate: expenseFormValues.conversionRate ?? null,
       title: expenseFormValues.title,
-      paidById: expenseFormValues.paidBy,
+      paidById,
       splitMode: expenseFormValues.splitMode,
       recurrenceRule: expenseFormValues.recurrenceRule,
       recurringExpenseLink: {
@@ -121,6 +163,15 @@ export async function createExpense(
           data: expenseFormValues.paidFor.map((paidFor) => ({
             userId: paidFor.participant,
             shares: paidFor.shares,
+          })),
+        },
+      },
+      // Create ExpensePaidBy rows for each payer entry
+      payers: {
+        createMany: {
+          data: expenseFormValues.paidBy.map((payer) => ({
+            userId: payer.participant,
+            amount: payer.amount,
           })),
         },
       },
@@ -185,6 +236,7 @@ export async function getGroupExpenseUserIds(groupId: string) {
     new Set(
       expenses.flatMap((e) => [
         e.paidBy.id,
+        ...(e.payers?.map((p) => p.userId) ?? []),
         ...e.paidFor.map((pf) => pf.user.id),
       ]),
     ),
@@ -235,12 +287,41 @@ export async function updateExpense(
 
   const memberIds = new Set(group.participants.map((p) => p.id))
 
-  if (!memberIds.has(expenseFormValues.paidBy)) {
+  // Validate all payer participant IDs are group members
+  for (const payer of expenseFormValues.paidBy) {
+    if (!memberIds.has(payer.participant)) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `User ${payer.participant} is not a group member`,
+      })
+    }
+  }
+
+  // Validate no duplicate userIds in paidBy
+  const payerUserIds = expenseFormValues.paidBy.map((p) => p.participant)
+  const uniquePayerIds = new Set(payerUserIds)
+  if (uniquePayerIds.size !== payerUserIds.length) {
+    const duplicate = payerUserIds.find(
+      (id, idx) => payerUserIds.indexOf(id) !== idx,
+    )
     throw new TRPCError({
       code: 'BAD_REQUEST',
-      message: 'paidBy user is not a group member',
+      message: `Duplicate payer: ${duplicate}`,
     })
   }
+
+  // Validate sum of payer amounts equals expense total
+  const payerAmountSum = expenseFormValues.paidBy.reduce(
+    (sum, entry) => sum + entry.amount,
+    0,
+  )
+  if (payerAmountSum !== expenseFormValues.amount) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Payer amounts must sum to expense total',
+    })
+  }
+
   for (const pf of expenseFormValues.paidFor) {
     if (!memberIds.has(pf.participant)) {
       throw new TRPCError({
@@ -301,7 +382,7 @@ export async function updateExpense(
       conversionRate: expenseFormValues.conversionRate ?? null,
       title: expenseFormValues.title,
       categoryId: expenseFormValues.category,
-      paidById: expenseFormValues.paidBy,
+      paidById: expenseFormValues.paidBy[0].participant,
       splitMode: expenseFormValues.splitMode,
       recurrenceRule: expenseFormValues.recurrenceRule,
       paidFor: {
@@ -335,6 +416,16 @@ export async function updateExpense(
               ),
           )
           .map((pf) => ({ expenseId: pf.expenseId, userId: pf.userId })),
+      },
+      // Delete all existing ExpensePaidBy rows and recreate with new payer entries
+      payers: {
+        deleteMany: { expenseId },
+        createMany: {
+          data: expenseFormValues.paidBy.map((entry) => ({
+            userId: entry.participant,
+            amount: entry.amount,
+          })),
+        },
       },
       recurringExpenseLink: {
         ...(isCreateRecurrenceExpenseLink
@@ -583,6 +674,13 @@ export async function getGroupExpenses(
           shares: true,
         },
       },
+      payers: {
+        select: {
+          userId: true,
+          amount: true,
+          user: { select: { id: true, name: true } },
+        },
+      },
       splitMode: true,
       recurrenceRule: true,
       title: true,
@@ -613,6 +711,13 @@ export async function getExpense(groupId: string, expenseId: string) {
       paidFor: {
         include: {
           user: { select: { id: true, name: true, email: true } },
+        },
+      },
+      payers: {
+        select: {
+          userId: true,
+          amount: true,
+          user: { select: { id: true, name: true } },
         },
       },
       category: true,
@@ -791,6 +896,7 @@ async function createRecurringExpenses() {
           include: {
             paidBy: true,
             paidFor: true,
+            payers: true,
             category: true,
             documents: true,
           },
@@ -817,6 +923,7 @@ async function createRecurringExpenses() {
         category,
         paidBy,
         paidFor,
+        payers,
         documents,
         ...destructuredCurrentExpenseRecord
       } = currentExpenseRecord
@@ -835,6 +942,14 @@ async function createRecurringExpenses() {
                   data: currentExpenseRecord.paidFor.map((paidFor) => ({
                     userId: paidFor.userId,
                     shares: paidFor.shares,
+                  })),
+                },
+              },
+              payers: {
+                createMany: {
+                  data: currentExpenseRecord.payers.map((payer) => ({
+                    userId: payer.userId,
+                    amount: payer.amount,
                   })),
                 },
               },
@@ -861,6 +976,7 @@ async function createRecurringExpenses() {
               documents: true,
               category: true,
               paidBy: true,
+              payers: true,
             },
           })
 

--- a/src/lib/balances.test.ts
+++ b/src/lib/balances.test.ts
@@ -129,3 +129,194 @@ describe('getReimbursements', () => {
     ])
   })
 })
+
+// --- Multi-payer unit tests ---
+
+function makeMultiPayerExpense(
+  payers: Array<{ id: string; amount: number }>,
+  participantIds: string[],
+  opts: { splitMode?: TestExpense['splitMode']; amount?: number } = {},
+): TestExpense {
+  const amount = opts.amount ?? payers.reduce((sum, p) => sum + p.amount, 0)
+  const splitMode = opts.splitMode ?? 'EVENLY'
+
+  return {
+    amount,
+    isReimbursement: false,
+    splitMode,
+    paidBy: { id: payers[0].id, name: payers[0].id },
+    paidFor: participantIds.map((id) => ({
+      user: { id, name: id },
+      shares: 1,
+    })),
+    payers: payers.map((p) => ({
+      userId: p.id,
+      amount: p.amount,
+      user: { id: p.id, name: p.id },
+    })),
+  } as TestExpense
+}
+
+describe('getBalances multi-payer', () => {
+  it('single payer backward compatibility: same result as legacy', () => {
+    // Single payer via payers array
+    const multiPayerExpense = makeMultiPayerExpense(
+      [{ id: 'alice', amount: 6000 }],
+      ['alice', 'bob', 'carol'],
+    )
+
+    // Single payer via legacy paidBy (no payers array)
+    const legacyExpense = makeEvenExpense(
+      'alice',
+      ['alice', 'bob', 'carol'],
+      6000,
+    )
+
+    const multiResult = getBalances([multiPayerExpense])
+    const legacyResult = getBalances([legacyExpense])
+
+    expect(multiResult).toEqual(legacyResult)
+  })
+
+  it('two payers splitting payment evenly', () => {
+    // Alice pays 5000, Bob pays 5000, total = 10000
+    // Split evenly among alice, bob, carol (each owes ~3333)
+    const expense = makeMultiPayerExpense(
+      [
+        { id: 'alice', amount: 5000 },
+        { id: 'bob', amount: 5000 },
+      ],
+      ['alice', 'bob', 'carol'],
+    )
+
+    const balances = getBalances([expense])
+
+    // Alice paid 5000
+    expect(balances['alice'].paid).toBe(5000)
+    // Bob paid 5000
+    expect(balances['bob'].paid).toBe(5000)
+    // Carol paid 0
+    expect(balances['carol'].paid).toBe(0)
+
+    // Total paid must equal expense amount
+    expect(
+      balances['alice'].paid + balances['bob'].paid + balances['carol'].paid,
+    ).toBe(10000)
+
+    // Each person's paidFor is rounded: 10000/3 ≈ 3333 for first two, last gets remainder ~3333
+    // After Math.round: all get 3333 (rounding remainder is fractional, rounds to same)
+    expect(balances['alice'].paidFor).toBe(3333)
+    expect(balances['bob'].paidFor).toBe(3333)
+    expect(balances['carol'].paidFor).toBe(3333)
+
+    // Each total = paid - paidFor
+    expect(balances['alice'].total).toBe(5000 - 3333)
+    expect(balances['bob'].total).toBe(5000 - 3333)
+    expect(balances['carol'].total).toBe(0 - 3333)
+  })
+
+  it('three payers with uneven amounts', () => {
+    // Alice: 5000, Bob: 3000, Carol: 2000 → total = 10000
+    // Split evenly among alice, bob, carol, dave (4 people)
+    const expense = makeMultiPayerExpense(
+      [
+        { id: 'alice', amount: 5000 },
+        { id: 'bob', amount: 3000 },
+        { id: 'carol', amount: 2000 },
+      ],
+      ['alice', 'bob', 'carol', 'dave'],
+    )
+
+    const balances = getBalances([expense])
+
+    expect(balances['alice'].paid).toBe(5000)
+    expect(balances['bob'].paid).toBe(3000)
+    expect(balances['carol'].paid).toBe(2000)
+    expect(balances['dave'].paid).toBe(0)
+
+    // Total paid = 10000
+    const totalPaid = Object.values(balances).reduce((s, b) => s + b.paid, 0)
+    expect(totalPaid).toBe(10000)
+
+    // Total paidFor = 10000
+    const totalPaidFor = Object.values(balances).reduce(
+      (s, b) => s + b.paidFor,
+      0,
+    )
+    expect(totalPaidFor).toBe(10000)
+
+    // Each person's total = paid - paidFor
+    for (const userId of Object.keys(balances)) {
+      expect(balances[userId].total).toBe(
+        balances[userId].paid - balances[userId].paidFor,
+      )
+    }
+
+    // Sum of all totals should be zero (zero-sum game)
+    const totalNet = Object.values(balances).reduce((s, b) => s + b.total, 0)
+    expect(totalNet).toBe(0)
+  })
+
+  it('payer who is also a beneficiary (net position)', () => {
+    // Alice pays 8000, Bob pays 2000, total = 10000
+    // Split evenly between alice and bob (each owes 5000)
+    const expense = makeMultiPayerExpense(
+      [
+        { id: 'alice', amount: 8000 },
+        { id: 'bob', amount: 2000 },
+      ],
+      ['alice', 'bob'],
+    )
+
+    const balances = getBalances([expense])
+
+    // Alice: paid 8000, paidFor 5000, net +3000
+    expect(balances['alice'].paid).toBe(8000)
+    expect(balances['alice'].paidFor).toBe(5000)
+    expect(balances['alice'].total).toBe(3000)
+
+    // Bob: paid 2000, paidFor 5000, net -3000
+    expect(balances['bob'].paid).toBe(2000)
+    expect(balances['bob'].paidFor).toBe(5000)
+    expect(balances['bob'].total).toBe(-3000)
+  })
+
+  it('rounding remainder with multiple payers', () => {
+    // Use an amount where the last-gets-remainder approach produces
+    // a visible difference: 10000 split among 3, total = 10000
+    // payer split: Alice 7000, Bob 3000
+    const expense = makeMultiPayerExpense(
+      [
+        { id: 'alice', amount: 7000 },
+        { id: 'bob', amount: 3000 },
+      ],
+      ['alice', 'bob', 'carol'],
+      { amount: 10000 },
+    )
+
+    const balances = getBalances([expense])
+
+    // Paid credits come from payers array
+    expect(balances['alice'].paid).toBe(7000)
+    expect(balances['bob'].paid).toBe(3000)
+    expect(balances['carol'].paid).toBe(0)
+
+    // paidFor with EVENLY split for 10000/3:
+    // First: 10000/3 = 3333.33 → remaining = 10000 - 3333.33 = 6666.67
+    // Second: 10000/3 = 3333.33 → remaining = 6666.67 - 3333.33 = 3333.33
+    // Third (last): remaining = 3333.33
+    // After Math.round: 3333, 3333, 3333
+    expect(balances['alice'].paidFor).toBe(3333)
+    expect(balances['bob'].paidFor).toBe(3333)
+    expect(balances['carol'].paidFor).toBe(3333)
+
+    // Net positions
+    expect(balances['alice'].total).toBe(7000 - 3333)
+    expect(balances['bob'].total).toBe(3000 - 3333)
+    expect(balances['carol'].total).toBe(0 - 3333)
+
+    // All payers are credited independently; rounding does not affect paid side
+    const totalPaid = Object.values(balances).reduce((s, b) => s + b.paid, 0)
+    expect(totalPaid).toBe(10000)
+  })
+})

--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -19,11 +19,23 @@ export function getBalances(
   const balances: Balances = {}
 
   for (const expense of expenses) {
-    const paidBy = expense.paidBy.id
     const paidFors = expense.paidFor
 
-    if (!balances[paidBy]) balances[paidBy] = { paid: 0, paidFor: 0, total: 0 }
-    balances[paidBy].paid += expense.amount
+    // Credit each payer by their individual amount (multi-payer support)
+    if (expense.payers && expense.payers.length > 0) {
+      for (const payer of expense.payers) {
+        const payerId = payer.user.id
+        if (!balances[payerId])
+          balances[payerId] = { paid: 0, paidFor: 0, total: 0 }
+        balances[payerId].paid += payer.amount
+      }
+    } else {
+      // Graceful degradation: fall back to single paidBy with full amount
+      const paidBy = expense.paidBy.id
+      if (!balances[paidBy])
+        balances[paidBy] = { paid: 0, paidFor: 0, total: 0 }
+      balances[paidBy].paid += expense.amount
+    }
 
     if (expense.splitMode === 'BY_PERCENTAGE') {
       for (const paidFor of paidFors) {
@@ -119,12 +131,28 @@ export function getDirectReimbursements(
 
   for (const expense of expenses) {
     const balances = getBalances([expense])
-    const payer = expense.paidBy.id
+
+    // Identify all payers (positive total) and debtors (negative total)
+    const payers: Array<{ userId: string; total: number }> = []
+    const debtors: Array<{ userId: string; total: number }> = []
 
     for (const [userId, { total }] of Object.entries(balances)) {
-      if (userId === payer || total >= 0) continue
-      const key = `${userId}:${payer}`
-      pairOwes.set(key, (pairOwes.get(key) ?? 0) + -total)
+      if (total > 0) payers.push({ userId, total })
+      else if (total < 0) debtors.push({ userId, total })
+    }
+
+    // Total credit across all payers for proportional distribution
+    const totalCredit = payers.reduce((sum, p) => sum + p.total, 0)
+
+    // Each debtor owes each payer proportionally to that payer's share of credit
+    for (const debtor of debtors) {
+      const debtAmount = -debtor.total
+      for (const payer of payers) {
+        const payerShare = (debtAmount * payer.total) / totalCredit
+        if (payerShare === 0) continue
+        const key = `${debtor.userId}:${payer.userId}`
+        pairOwes.set(key, (pairOwes.get(key) ?? 0) + payerShare)
+      }
     }
   }
 

--- a/src/lib/distribute-amount.test.ts
+++ b/src/lib/distribute-amount.test.ts
@@ -1,0 +1,43 @@
+import {
+  distributeEqualAmounts,
+  distributeWeightedAmounts,
+} from '@/lib/distribute-amount'
+
+describe('distributeEqualAmounts', () => {
+  it('splits €100 across 3 with conserved cents', () => {
+    const parts = distributeEqualAmounts(100, 3, 2)
+    expect(parts).toEqual([33.34, 33.33, 33.33])
+    expect(parts.reduce((s, n) => s + n, 0)).toBeCloseTo(100, 10)
+  })
+
+  it('returns the full total for a single recipient', () => {
+    expect(distributeEqualAmounts(21.5, 1, 2)).toEqual([21.5])
+  })
+
+  it('returns an empty array for count 0', () => {
+    expect(distributeEqualAmounts(100, 0, 2)).toEqual([])
+  })
+})
+
+describe('distributeWeightedAmounts', () => {
+  it('splits by shares 1:1:1 like equal', () => {
+    const parts = distributeWeightedAmounts(100, [1, 1, 1], 2)
+    expect(parts.reduce((s, n) => s + n, 0)).toBeCloseTo(100, 10)
+    expect(parts.every((p) => p === 33.33 || p === 33.34)).toBe(true)
+  })
+
+  it('splits 1:2 for €90 → 30 and 60', () => {
+    expect(distributeWeightedAmounts(90, [1, 2], 2)).toEqual([30, 60])
+  })
+
+  it('falls back to equal when all weights are zero', () => {
+    expect(distributeWeightedAmounts(10, [0, 0], 2)).toEqual([5, 5])
+  })
+})
+
+describe('single-payer full total', () => {
+  it('emits one share equal to the expense total', () => {
+    const total = 42.07
+    expect(distributeEqualAmounts(total, 1, 2)).toEqual([total])
+  })
+})

--- a/src/lib/distribute-amount.ts
+++ b/src/lib/distribute-amount.ts
@@ -1,0 +1,64 @@
+/**
+ * Digit-aware distribution of a monetary total across N recipients.
+ * Works in major units (e.g. euros) using integer minor-unit arithmetic
+ * so remainders are not lost to floating-point / Math.floor on majors.
+ */
+
+export function distributeEqualAmounts(
+  totalMajor: number,
+  count: number,
+  decimalDigits: number,
+): number[] {
+  if (count <= 0) return []
+  const factor = 10 ** decimalDigits
+  const totalMinor = Math.round(totalMajor * factor)
+  if (count === 1) return [totalMinor / factor]
+
+  const baseMinor = Math.floor(totalMinor / count)
+  const remainder = totalMinor - baseMinor * count
+
+  return Array.from({ length: count }, (_, index) => {
+    const minor = baseMinor + (index < remainder ? 1 : 0)
+    return minor / factor
+  })
+}
+
+/**
+ * Distribute `totalMajor` proportionally to non-negative `weights`.
+ * Zero total weight → equal split. Remainder cents go to earliest indices.
+ */
+export function distributeWeightedAmounts(
+  totalMajor: number,
+  weights: number[],
+  decimalDigits: number,
+): number[] {
+  const count = weights.length
+  if (count === 0) return []
+
+  const safeWeights = weights.map((w) => (w > 0 ? w : 0))
+  const weightSum = safeWeights.reduce((sum, w) => sum + w, 0)
+  if (weightSum <= 0) {
+    return distributeEqualAmounts(totalMajor, count, decimalDigits)
+  }
+
+  const factor = 10 ** decimalDigits
+  const totalMinor = Math.round(totalMajor * factor)
+
+  const rawMinors = safeWeights.map((w) => (totalMinor * w) / weightSum)
+  const floored = rawMinors.map((m) => Math.floor(m))
+  let remainder = totalMinor - floored.reduce((sum, m) => sum + m, 0)
+
+  // Give leftover cents to entries with the largest fractional parts first
+  const order = rawMinors
+    .map((m, i) => ({ i, frac: m - floored[i] }))
+    .sort((a, b) => b.frac - a.frac)
+
+  const minors = [...floored]
+  for (const { i } of order) {
+    if (remainder <= 0) break
+    minors[i] += 1
+    remainder -= 1
+  }
+
+  return minors.map((m) => m / factor)
+}

--- a/src/lib/expense-copy.ts
+++ b/src/lib/expense-copy.ts
@@ -8,6 +8,7 @@ export type CopyableExpense = {
   amount: number // minor units (cents)
   categoryId: number | null
   paidById: string
+  payers?: Array<{ userId: string; amount: number }>
   splitMode: SplitMode
   isReimbursement: boolean
   notes: string | null
@@ -25,7 +26,13 @@ export function buildCopyExpensePrefill(
     expenseDate: new Date(), // today
     amount,
     category: expense.categoryId ?? 0,
-    paidBy: expense.paidById,
+    paidBy:
+      expense.payers && expense.payers.length > 0
+        ? expense.payers.map((p) => ({
+            participant: p.userId,
+            amount: amountAsDecimal(p.amount, currency),
+          }))
+        : expense.paidById,
     splitMode: expense.splitMode,
     isReimbursement: expense.isReimbursement,
     notes: expense.notes ?? '',

--- a/src/lib/expense-detail-splits.ts
+++ b/src/lib/expense-detail-splits.ts
@@ -8,6 +8,11 @@ type SplitExpense = {
   isReimbursement: boolean
   splitMode: SplitMode
   paidBy: { id: string; name?: string | null; email?: string | null }
+  payers?: Array<{
+    userId: string
+    amount: number
+    user: { id: string; name: string | null }
+  }>
   paidFor: Array<{
     user: { id: string; name: string | null; email?: string | null }
     shares: number
@@ -47,7 +52,10 @@ export function buildExpenseSplitLines(
       name: entry.user.name ?? entry.user.email ?? '',
       amount: getParticipantShareAmount(expense, entry.user.id),
       isCurrentUser: entry.user.id === currentUserId,
-      isPayer: entry.user.id === expense.paidBy.id,
+      isPayer:
+        expense.payers && expense.payers.length > 0
+          ? expense.payers.some((p) => p.userId === entry.user.id)
+          : entry.user.id === expense.paidBy.id,
     }))
     .filter((line) => line.amount > 0)
 }

--- a/src/lib/friend-activities.ts
+++ b/src/lib/friend-activities.ts
@@ -90,6 +90,13 @@ export async function getFriendActivities(
           shares: true,
         },
       },
+      payers: {
+        select: {
+          userId: true,
+          amount: true,
+          user: { select: { id: true, name: true } },
+        },
+      },
       _count: { select: { documents: true } },
     },
   })

--- a/src/lib/friend-balances-db.ts
+++ b/src/lib/friend-balances-db.ts
@@ -27,6 +27,13 @@ export async function getDirectExpensesBetweenUsers(
           shares: true,
         },
       },
+      payers: {
+        select: {
+          userId: true,
+          amount: true,
+          user: { select: { id: true, name: true } },
+        },
+      },
       splitMode: true,
       recurrenceRule: true,
       title: true,

--- a/src/lib/friend-balances.test.ts
+++ b/src/lib/friend-balances.test.ts
@@ -124,6 +124,7 @@ describe('computeFriendBalance', () => {
           { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
           { user: { id: friendUserId, name: 'Friend' }, shares: 1 },
         ],
+        payers: [],
       },
     ]
 
@@ -182,6 +183,7 @@ describe('computeFriendBalance', () => {
           { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
           { user: { id: friendUserId, name: 'Friend' }, shares: 1 },
         ],
+        payers: [],
       },
     ]
 
@@ -263,6 +265,7 @@ describe('computeFriendBalance', () => {
           { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
           { user: { id: friendUserId, name: 'Friend' }, shares: 1 },
         ],
+        payers: [],
       },
     ]
 
@@ -316,6 +319,7 @@ describe('computeFriendBalance', () => {
             { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
             { user: { id: friendUserId, name: 'Friend' }, shares: 1 },
           ],
+          payers: [],
         },
       ]
 
@@ -362,6 +366,7 @@ describe('computeFriendBalance', () => {
             { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
             { user: { id: friendUserId, name: 'Friend' }, shares: 1 },
           ],
+          payers: [],
         },
         {
           id: 'direct-payment-1',
@@ -382,6 +387,7 @@ describe('computeFriendBalance', () => {
           paidFor: [
             { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
           ],
+          payers: [],
         },
       ]
 
@@ -425,6 +431,7 @@ describe('computeFriendBalance', () => {
             { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
             { user: { id: friendUserId, name: 'Friend' }, shares: 1 },
           ],
+          payers: [],
         },
         {
           id: 'direct-expense-2',
@@ -446,6 +453,7 @@ describe('computeFriendBalance', () => {
             { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
             { user: { id: friendUserId, name: 'Friend' }, shares: 1 },
           ],
+          payers: [],
         },
       ]
 
@@ -492,6 +500,7 @@ describe('computeFriendBalance', () => {
             { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
             { user: { id: friendUserId, name: 'Friend' }, shares: 1 },
           ],
+          payers: [],
         },
       ]
 
@@ -516,6 +525,7 @@ describe('computeFriendBalance', () => {
             { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
             { user: { id: friendUserId, name: 'Friend' }, shares: 1 },
           ],
+          payers: [],
         },
       ]
 
@@ -589,6 +599,7 @@ describe('computeFriendBalance', () => {
             { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
             { user: { id: friendUserId, name: 'Friend' }, shares: 1 },
           ],
+          payers: [],
         },
       ]
 
@@ -613,6 +624,7 @@ describe('computeFriendBalance', () => {
             { user: { id: currentUserId, name: 'Current User' }, shares: 1 },
             { user: { id: friendUserId, name: 'Friend' }, shares: 1 },
           ],
+          payers: [],
         },
       ]
 

--- a/src/lib/friend-timeline.test.ts
+++ b/src/lib/friend-timeline.test.ts
@@ -64,6 +64,7 @@ function makeExpense(
       { user: { id: CURRENT_USER_ID, name: 'Current User' }, shares: 1 },
       { user: { id: FRIEND_USER_ID, name: 'Friend' }, shares: 1 },
     ],
+    payers: [],
   }
 }
 

--- a/src/lib/knots-import.test.ts
+++ b/src/lib/knots-import.test.ts
@@ -58,7 +58,9 @@ describe('parseKnotsExport', () => {
     const expenses = await parseKnotsExport(exportJson, 'group-1')
 
     expect(expenses).toHaveLength(1)
-    expect(expenses[0].paidBy).toBe('user-ana')
+    expect(expenses[0].paidBy).toEqual([
+      { participant: 'user-ana', amount: 3466 },
+    ])
     expect(expenses[0].paidFor).toEqual([
       { participant: 'user-ana', shares: 1733 },
       { participant: 'user-rafael', shares: 1733 },
@@ -200,5 +202,104 @@ describe('parseKnotsExport', () => {
     await expect(parseKnotsExport(exportJson, 'group-1')).rejects.toThrow(
       'These export participants are not in the group: Unknown Person',
     )
+  })
+
+  describe('multi-payer import', () => {
+    it('JSON with paidBy array creates correct multi-payer entries', async () => {
+      const exportJson = JSON.stringify({
+        participants: [
+          { id: 'user-ana', name: 'Ana Ferreira' },
+          { id: 'user-rafael', name: 'Rafael Macedo' },
+        ],
+        expenses: [
+          {
+            expenseDate: '2023-05-10T00:00:00.000Z',
+            title: 'Dinner',
+            amount: 5000,
+            paidById: 'user-ana',
+            paidBy: [
+              { userId: 'user-ana', amount: 3000 },
+              { userId: 'user-rafael', amount: 2000 },
+            ],
+            paidFor: [
+              { userId: 'user-ana', shares: 2500 },
+              { userId: 'user-rafael', shares: 2500 },
+            ],
+            isReimbursement: false,
+            splitMode: 'EVENLY',
+          },
+        ],
+      })
+
+      const expenses = await parseKnotsExport(exportJson, 'group-1')
+
+      expect(expenses).toHaveLength(1)
+      expect(expenses[0].paidBy).toEqual([
+        { participant: 'user-ana', amount: 3000 },
+        { participant: 'user-rafael', amount: 2000 },
+      ])
+    })
+
+    it('legacy JSON without paidBy array creates single-payer entry with full amount', async () => {
+      const exportJson = JSON.stringify({
+        participants: [
+          { id: 'user-ana', name: 'Ana Ferreira' },
+          { id: 'user-rafael', name: 'Rafael Macedo' },
+        ],
+        expenses: [
+          {
+            expenseDate: '2023-05-10T00:00:00.000Z',
+            title: 'Groceries',
+            amount: 4200,
+            paidById: 'user-rafael',
+            paidFor: [
+              { userId: 'user-ana', shares: 2100 },
+              { userId: 'user-rafael', shares: 2100 },
+            ],
+            isReimbursement: false,
+            splitMode: 'EVENLY',
+          },
+        ],
+      })
+
+      const expenses = await parseKnotsExport(exportJson, 'group-1')
+
+      expect(expenses).toHaveLength(1)
+      expect(expenses[0].paidBy).toEqual([
+        { participant: 'user-rafael', amount: 4200 },
+      ])
+    })
+
+    it('unknown userId in paidBy array throws descriptive error', async () => {
+      const exportJson = JSON.stringify({
+        participants: [
+          { id: 'user-ana', name: 'Ana Ferreira' },
+          { id: 'user-rafael', name: 'Rafael Macedo' },
+          { id: 'user-unknown', name: 'Ghost User' },
+        ],
+        expenses: [
+          {
+            expenseDate: '2023-05-10T00:00:00.000Z',
+            title: 'Taxi',
+            amount: 3000,
+            paidById: 'user-ana',
+            paidBy: [
+              { userId: 'user-ana', amount: 1500 },
+              { userId: 'user-unknown', amount: 1500 },
+            ],
+            paidFor: [
+              { userId: 'user-ana', shares: 1500 },
+              { userId: 'user-rafael', shares: 1500 },
+            ],
+            isReimbursement: false,
+            splitMode: 'EVENLY',
+          },
+        ],
+      })
+
+      await expect(parseKnotsExport(exportJson, 'group-1')).rejects.toThrow(
+        /Ghost User/,
+      )
+    })
   })
 })

--- a/src/lib/knots-import.ts
+++ b/src/lib/knots-import.ts
@@ -28,6 +28,14 @@ const knotsExportExpenseSchema = z.object({
   originalCurrency: z.string().nullable().optional(),
   conversionRate: z.union([z.number(), z.string()]).nullable().optional(),
   paidById: z.string(),
+  paidBy: z
+    .array(
+      z.object({
+        userId: z.string(),
+        amount: z.number().int(),
+      }),
+    )
+    .optional(),
   paidFor: z.array(
     z.object({
       userId: z.string(),
@@ -231,6 +239,11 @@ function buildParticipantMatchReport(
 
   for (const expense of exportData.expenses) {
     const participantIds = new Set<string>([expense.paidById])
+    if (expense.paidBy) {
+      for (const entry of expense.paidBy) {
+        participantIds.add(entry.userId)
+      }
+    }
     for (const entry of expense.paidFor) {
       participantIds.add(entry.userId)
     }
@@ -264,6 +277,11 @@ function collectReferencedParticipantIds(exportData: KnotsExport): Set<string> {
 
   for (const expense of exportData.expenses) {
     referencedIds.add(expense.paidById)
+    if (expense.paidBy) {
+      for (const entry of expense.paidBy) {
+        referencedIds.add(entry.userId)
+      }
+    }
     for (const entry of expense.paidFor) {
       referencedIds.add(entry.userId)
     }
@@ -495,13 +513,31 @@ function convertExportExpense(
     throw new Error(`Invalid expense date on row ${index + 1}`)
   }
 
-  let paidBy: string
-  try {
-    paidBy = mapParticipantId(expense.paidById)
-  } catch (error) {
-    throw new Error(
-      `Expense "${expense.title}" (row ${index + 1}): ${error instanceof Error ? error.message : error}`,
-    )
+  // Build paidBy array: use explicit paidBy array if present, otherwise fallback to legacy paidById
+  let paidBy: Array<{ participant: string; amount: number }>
+  if (expense.paidBy && expense.paidBy.length > 0) {
+    paidBy = expense.paidBy.map((entry) => {
+      let participant: string
+      try {
+        participant = mapParticipantId(entry.userId)
+      } catch (error) {
+        throw new Error(
+          `Expense "${expense.title}" (row ${index + 1}): payer ${error instanceof Error ? error.message : error}`,
+        )
+      }
+      return { participant, amount: entry.amount }
+    })
+  } else {
+    // Legacy fallback: single payer from paidById with full amount
+    let participant: string
+    try {
+      participant = mapParticipantId(expense.paidById)
+    } catch (error) {
+      throw new Error(
+        `Expense "${expense.title}" (row ${index + 1}): ${error instanceof Error ? error.message : error}`,
+      )
+    }
+    paidBy = [{ participant, amount: expense.amount }]
   }
 
   const paidForMap = new Map<string, number>()

--- a/src/lib/math-expression.property.test.ts
+++ b/src/lib/math-expression.property.test.ts
@@ -355,7 +355,7 @@ describe('Feature: expense-amount-math-expressions, Property 5: Schema Expressio
           title: 'Test',
           category: 0,
           amount: printed,
-          paidBy: 'user1',
+          paidBy: [{ participant: 'user1', amount: evalResult.value }],
           paidFor: [{ participant: 'user2', shares: '100' }],
           splitMode: 'EVENLY',
           saveDefaultSplittingOptions: false,

--- a/src/lib/schemas.test.ts
+++ b/src/lib/schemas.test.ts
@@ -1,0 +1,101 @@
+import { expenseFormSchema } from '@/lib/schemas'
+
+/** Minimal valid expense base input. Non-paidBy fields are held constant. */
+function validExpenseInput(
+  paidBy: Array<{ participant: string; amount: number }>,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    expenseDate: new Date('2024-06-01'),
+    title: 'Groceries',
+    category: 0,
+    amount: 5000, // 50.00 in minor units conceptually, but schema treats as raw number
+    paidBy,
+    paidFor: [{ participant: 'user-1', shares: 5000 }],
+    splitMode: 'BY_AMOUNT',
+    saveDefaultSplittingOptions: false,
+    isReimbursement: false,
+    ...overrides,
+  }
+}
+
+describe('expenseFormSchema – paidBy validation', () => {
+  it('accepts a single payer whose amount equals the total', () => {
+    const input = validExpenseInput([{ participant: 'user-1', amount: 5000 }])
+    const result = expenseFormSchema.safeParse(input)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts two payers whose amounts sum to the total', () => {
+    const input = validExpenseInput([
+      { participant: 'user-1', amount: 2000 },
+      { participant: 'user-2', amount: 3000 },
+    ])
+    const result = expenseFormSchema.safeParse(input)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a payer amount that is zero or negative', () => {
+    const inputZero = validExpenseInput([{ participant: 'user-1', amount: 0 }])
+    const resultZero = expenseFormSchema.safeParse(inputZero)
+    expect(resultZero.success).toBe(false)
+
+    const inputNeg = validExpenseInput([
+      { participant: 'user-1', amount: -100 },
+    ])
+    const resultNeg = expenseFormSchema.safeParse(inputNeg)
+    expect(resultNeg.success).toBe(false)
+  })
+
+  it('rejects payer amounts that do not sum to the total', () => {
+    const input = validExpenseInput([
+      { participant: 'user-1', amount: 2000 },
+      { participant: 'user-2', amount: 1000 },
+    ])
+    const result = expenseFormSchema.safeParse(input)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain('paidByAmountSum')
+    }
+  })
+
+  it('rejects a reimbursement with more than one payer', () => {
+    const input = validExpenseInput(
+      [
+        { participant: 'user-1', amount: 2500 },
+        { participant: 'user-2', amount: 2500 },
+      ],
+      { isReimbursement: true, category: 1, title: '' },
+    )
+    const result = expenseFormSchema.safeParse(input)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain('reimbursementSinglePayer')
+    }
+  })
+
+  it('rejects an empty paidBy array', () => {
+    const input = validExpenseInput([])
+    const result = expenseFormSchema.safeParse(input)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const codes = result.error.issues.map((i) => i.code)
+      expect(codes).toContain('too_small')
+    }
+  })
+
+  it('rejects duplicate payer participants', () => {
+    const input = validExpenseInput([
+      { participant: 'user-1', amount: 2000 },
+      { participant: 'user-1', amount: 3000 },
+    ])
+    const result = expenseFormSchema.safeParse(input)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain('paidByDuplicateParticipants')
+    }
+  })
+})

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -83,6 +83,13 @@ const inputCoercedToNumber = z.union([
   }),
 ])
 
+export const paidByEntrySchema = z.object({
+  participant: z.string().min(1),
+  amount: z
+    .union([z.number(), z.string().transform(expressionToNumber)])
+    .refine((a) => a > 0, 'paidByAmountPositive'),
+})
+
 export const expenseFormSchema = z
   .object({
     expenseDate: z.coerce.date(),
@@ -109,7 +116,7 @@ export const expenseFormSchema = z
         inputCoercedToNumber.refine((amount) => amount > 0, 'ratePositive'),
       ])
       .nullish(),
-    paidBy: z.string({ required_error: 'paidByRequired' }),
+    paidBy: z.array(paidByEntrySchema).min(1, 'paidByRequired'),
     paidFor: z
       .array(
         z.object({
@@ -192,6 +199,40 @@ export const expenseFormSchema = z
         code: z.ZodIssueCode.custom,
         message: 'min2',
         path: ['title'],
+      })
+    }
+
+    // Reimbursements must have exactly one payer
+    if (expense.isReimbursement && expense.paidBy.length > 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'reimbursementSinglePayer',
+        path: ['paidBy'],
+      })
+    }
+
+    // No duplicate payer participants
+    const payerIds = expense.paidBy.map((entry) => entry.participant)
+    if (new Set(payerIds).size !== payerIds.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'paidByDuplicateParticipants',
+        path: ['paidBy'],
+      })
+    }
+
+    // Sum of payer amounts must equal expense amount
+    const payerSum = expense.paidBy.reduce(
+      (sum, entry) => sum + entry.amount,
+      0,
+    )
+    const amountMinor = toAmountMinorUnitsForValidation(expense.amount)
+    const payerSumMinor = toAmountMinorUnitsForValidation(payerSum)
+    if (payerSumMinor !== amountMinor) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'paidByAmountSum',
+        path: ['paidBy'],
       })
     }
 

--- a/src/lib/settlements.test.ts
+++ b/src/lib/settlements.test.ts
@@ -87,6 +87,7 @@ describe('buildSettlementFormValues', () => {
           { user: { id: 'rafael', name: 'Rafael' }, shares: 1 },
           { user: { id: 'ana', name: 'Ana' }, shares: 1 },
         ],
+        payers: [{ user: { id: 'rafael', name: 'Rafael' }, amount: 10000 }],
       },
     ]
 
@@ -111,10 +112,14 @@ describe('buildSettlementFormValues', () => {
         amount: settlement.amount,
         isReimbursement: true,
         splitMode: settlement.splitMode,
-        paidBy: { id: settlement.paidBy, name: 'Ana' },
+        paidBy: { id: settlement.paidBy[0].participant, name: 'Ana' },
         paidFor: settlement.paidFor.map((pf) => ({
           user: { id: pf.participant, name: pf.participant },
           shares: pf.shares,
+        })),
+        payers: settlement.paidBy.map((p) => ({
+          user: { id: p.participant, name: p.participant },
+          amount: p.amount,
         })),
       },
     ] as any)
@@ -133,6 +138,7 @@ describe('buildSettlementFormValues', () => {
           { user: { id: 'rafael', name: 'Rafael' }, shares: 1 },
           { user: { id: 'ana', name: 'Ana' }, shares: 1 },
         ],
+        payers: [{ user: { id: 'rafael', name: 'Rafael' }, amount: 10000 }],
       },
     ]
 
@@ -149,10 +155,14 @@ describe('buildSettlementFormValues', () => {
         amount: partialSettlement.amount,
         isReimbursement: true,
         splitMode: partialSettlement.splitMode,
-        paidBy: { id: partialSettlement.paidBy, name: 'Ana' },
+        paidBy: { id: partialSettlement.paidBy[0].participant, name: 'Ana' },
         paidFor: partialSettlement.paidFor.map((pf) => ({
           user: { id: pf.participant, name: pf.participant },
           shares: pf.shares,
+        })),
+        payers: partialSettlement.paidBy.map((p) => ({
+          user: { id: p.participant, name: p.participant },
+          amount: p.amount,
         })),
       },
     ] as any)

--- a/src/lib/settlements.ts
+++ b/src/lib/settlements.ts
@@ -92,7 +92,7 @@ export function buildSettlementFormValues(
     title,
     category: PAYMENT_CATEGORY_ID,
     amount: amountMinor,
-    paidBy: fromUserId,
+    paidBy: [{ participant: fromUserId, amount: amountMinor }],
     paidFor: [{ participant: toUserId, shares: amountMinor }],
     splitMode: 'BY_AMOUNT',
     saveDefaultSplittingOptions: false,

--- a/src/lib/splitwise-import.test.ts
+++ b/src/lib/splitwise-import.test.ts
@@ -65,7 +65,56 @@ describe('splitwise-import', () => {
     })
 
     expect(expenses).toHaveLength(2)
-    expect(expenses[0].paidBy).toBe('user-rafael')
-    expect(expenses[1].paidBy).toBe('user-ana')
+    expect(expenses[0].paidBy).toEqual([
+      { participant: 'user-rafael', amount: 1000 },
+    ])
+    expect(expenses[1].paidBy).toEqual([
+      { participant: 'user-ana', amount: 400 },
+    ])
+  })
+
+  it('detects multi-payer rows and creates paidBy array', async () => {
+    const multiPayerCSV = `Date,Description,Category,Cost,Currency,Rafael,Ana
+2026-01-01,Dinner,General,30.00,EUR,20.00,10.00`
+
+    const expenses = await parseSplitwiseCSV(multiPayerCSV, 'group-1', {
+      csvNameToUserId: {
+        Rafael: 'user-rafael',
+        Ana: 'user-ana',
+      },
+    })
+
+    expect(expenses).toHaveLength(1)
+    expect(expenses[0].paidBy).toEqual([
+      { participant: 'user-rafael', amount: 2000 },
+      { participant: 'user-ana', amount: 1000 },
+    ])
+  })
+
+  it('adjusts last payer amount to reconcile rounding differences', async () => {
+    // Cost is 10.00 (1000 cents), but payer columns sum to 10.01 (1001 cents)
+    const roundingCSV = `Date,Description,Category,Cost,Currency,Rafael,Ana
+2026-01-01,Lunch,General,10.00,EUR,6.67,3.34`
+
+    const expenses = await parseSplitwiseCSV(roundingCSV, 'group-1', {
+      csvNameToUserId: {
+        Rafael: 'user-rafael',
+        Ana: 'user-ana',
+      },
+    })
+
+    expect(expenses).toHaveLength(1)
+    const paidBy = expenses[0].paidBy
+    expect(paidBy).toHaveLength(2)
+    // Sum of payer amounts must equal cost (1000 cents)
+    const totalPaid = paidBy.reduce(
+      (sum: number, entry: { amount: number }) => sum + entry.amount,
+      0,
+    )
+    expect(totalPaid).toBe(1000)
+    // First payer keeps their original amount
+    expect(paidBy[0].amount).toBe(667)
+    // Last payer is adjusted: 334 + (1000 - 1001) = 333
+    expect(paidBy[1].amount).toBe(333)
   })
 })

--- a/src/lib/splitwise-import.ts
+++ b/src/lib/splitwise-import.ts
@@ -317,8 +317,6 @@ async function parseExpenseRow(
     : 0
 
   const userAmounts = new Map<string, number>()
-  let paidByCsvName = ''
-  let maxAmount = -Infinity
 
   for (const userColumn of userColumns) {
     const userIndex = headers.indexOf(userColumn)
@@ -326,19 +324,34 @@ async function parseExpenseRow(
       const amount = parseFloat(row[userIndex]) || 0
       const amountInCents = Math.round(amount * 100)
       userAmounts.set(userColumn, amountInCents)
-
-      if (amountInCents > maxAmount) {
-        maxAmount = amountInCents
-        paidByCsvName = userColumn
-      }
     }
   }
 
-  if (!paidByCsvName) {
+  // Detect payers: users with positive column values
+  const payerEntries: Array<{ csvName: string; amount: number }> = []
+  for (const userColumn of userColumns) {
+    const amount = userAmounts.get(userColumn) ?? 0
+    if (amount > 0) {
+      payerEntries.push({ csvName: userColumn, amount })
+    }
+  }
+
+  if (payerEntries.length === 0) {
     throw new Error('Could not determine who paid for this expense')
   }
 
-  const paidBy = resolveCsvName(paidByCsvName)
+  // Build paidBy array with each payer's positive column value as their amount
+  const paidBy: Array<{ participant: string; amount: number }> =
+    payerEntries.map((entry) => ({
+      participant: resolveCsvName(entry.csvName),
+      amount: entry.amount,
+    }))
+
+  // Reconcile rounding: adjust last payer's amount if sum doesn't match cost
+  const payerSum = paidBy.reduce((sum, entry) => sum + entry.amount, 0)
+  if (payerSum !== costInCents) {
+    paidBy[paidBy.length - 1].amount += costInCents - payerSum
+  }
 
   const paidFor: Array<{ participant: string; shares: number }> = []
 

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -289,15 +289,29 @@ export function computeParticipantRanking(
 
   // Accumulate paid amounts
   for (const expense of nonReimbursements) {
-    const existing = paidMap.get(expense.paidBy.id)
-    if (existing) {
-      existing.totalPaid += expense.amount
+    if (expense.payers && expense.payers.length > 0) {
+      for (const payer of expense.payers) {
+        const payerId = payer.user.id
+        const existing = paidMap.get(payerId)
+        if (existing) {
+          existing.totalPaid += payer.amount
+        } else {
+          paidMap.set(payerId, {
+            name: payer.user.name,
+            totalPaid: payer.amount,
+          })
+        }
+      }
     } else {
-      // Participant not in the list but paid for an expense
-      paidMap.set(expense.paidBy.id, {
-        name: expense.paidBy.name,
-        totalPaid: expense.amount,
-      })
+      const existing = paidMap.get(expense.paidBy.id)
+      if (existing) {
+        existing.totalPaid += expense.amount
+      } else {
+        paidMap.set(expense.paidBy.id, {
+          name: expense.paidBy.name,
+          totalPaid: expense.amount,
+        })
+      }
     }
   }
 
@@ -343,15 +357,31 @@ export function computeExpenseDistribution(
 
   // Accumulate paid amounts
   for (const expense of nonReimbursements) {
-    const existing = distributionMap.get(expense.paidBy.id)
-    if (existing) {
-      existing.totalPaid += expense.amount
+    if (expense.payers && expense.payers.length > 0) {
+      for (const payer of expense.payers) {
+        const payerId = payer.user.id
+        const existing = distributionMap.get(payerId)
+        if (existing) {
+          existing.totalPaid += payer.amount
+        } else {
+          distributionMap.set(payerId, {
+            name: payer.user.name,
+            totalPaid: payer.amount,
+            totalShare: 0,
+          })
+        }
+      }
     } else {
-      distributionMap.set(expense.paidBy.id, {
-        name: expense.paidBy.name,
-        totalPaid: expense.amount,
-        totalShare: 0,
-      })
+      const existing = distributionMap.get(expense.paidBy.id)
+      if (existing) {
+        existing.totalPaid += expense.amount
+      } else {
+        distributionMap.set(expense.paidBy.id, {
+          name: expense.paidBy.name,
+          totalPaid: expense.amount,
+          totalShare: 0,
+        })
+      }
     }
   }
 
@@ -478,10 +508,19 @@ export function computePaidVsSharePercentages(
 
   // Accumulate paid amounts and shares
   for (const expense of nonReimbursements) {
-    const payerId = expense.paidBy.id
-    const payerEntry = paidMap.get(payerId)
-    if (payerEntry) {
-      payerEntry.totalPaid += expense.amount
+    if (expense.payers && expense.payers.length > 0) {
+      for (const payer of expense.payers) {
+        const payerEntry = paidMap.get(payer.user.id)
+        if (payerEntry) {
+          payerEntry.totalPaid += payer.amount
+        }
+      }
+    } else {
+      const payerId = expense.paidBy.id
+      const payerEntry = paidMap.get(payerId)
+      if (payerEntry) {
+        payerEntry.totalPaid += expense.amount
+      }
     }
 
     for (const participant of participants) {

--- a/src/lib/totals.ts
+++ b/src/lib/totals.ts
@@ -14,13 +14,14 @@ export function getTotalActiveUserPaidFor(
   activeUserId: string | null,
   expenses: NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>,
 ): number {
-  return expenses.reduce(
-    (total, expense) =>
-      expense.paidBy.id === activeUserId && !expense.isReimbursement
-        ? total + expense.amount
-        : total,
-    0,
-  )
+  return expenses.reduce((total, expense) => {
+    if (expense.isReimbursement) return total
+    if (expense.payers && expense.payers.length > 0) {
+      const payer = expense.payers.find((p) => p.userId === activeUserId)
+      return payer ? total + payer.amount : total
+    }
+    return expense.paidBy.id === activeUserId ? total + expense.amount : total
+  }, 0)
 }
 
 type Expense = NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>[number]

--- a/src/trpc/routers/friends/index.ts
+++ b/src/trpc/routers/friends/index.ts
@@ -506,6 +506,13 @@ export const friendsRouter = createTRPCRouter({
               shares: true,
             },
           },
+          payers: {
+            select: {
+              userId: true,
+              amount: true,
+              user: { select: { id: true, name: true } },
+            },
+          },
           splitMode: true,
           recurrenceRule: true,
           title: true,
@@ -641,6 +648,13 @@ export const friendsRouter = createTRPCRouter({
             select: {
               user: { select: { id: true, name: true } },
               shares: true,
+            },
+          },
+          payers: {
+            select: {
+              userId: true,
+              amount: true,
+              user: { select: { id: true, name: true } },
             },
           },
           _count: { select: { documents: true } },
@@ -781,6 +795,9 @@ export const friendsRouter = createTRPCRouter({
                 { userId: friendUserId, shares: 1 },
               ],
             },
+          },
+          payers: {
+            create: [{ userId: input.paidById, amount: input.amount }],
           },
         },
         include: {
@@ -1026,6 +1043,9 @@ export const friendsRouter = createTRPCRouter({
                     })),
                   },
                 },
+                payers: {
+                  create: [{ userId: paidByUserId, amount: groupAmountMinor }],
+                },
                 documents: {
                   createMany: {
                     data: input.documents.map((doc) => ({
@@ -1120,6 +1140,11 @@ export const friendsRouter = createTRPCRouter({
                     { userId: dId, shares: 1 },
                   ],
                 },
+              },
+              payers: {
+                create: [
+                  { userId: paidByUserId, amount: directShareAmount * 2 },
+                ],
               },
               documents: {
                 createMany: {
@@ -1427,6 +1452,9 @@ export const friendsRouter = createTRPCRouter({
                   shares: 1,
                 },
               },
+              payers: {
+                create: [{ userId: bucket.from, amount: bucket.amount }],
+              },
             },
             include: {
               paidBy: { select: { id: true, name: true } },
@@ -1509,6 +1537,9 @@ export const friendsRouter = createTRPCRouter({
               userId: input.toUserId,
               shares: 1,
             },
+          },
+          payers: {
+            create: [{ userId: input.fromUserId, amount: input.amount }],
           },
         },
         include: {
@@ -1744,7 +1775,7 @@ export const friendsRouter = createTRPCRouter({
           conversionRate: expenseFormValues.conversionRate,
           title: expenseFormValues.title,
           categoryId: expenseFormValues.category,
-          paidById: expenseFormValues.paidBy,
+          paidById: expenseFormValues.paidBy[0].participant,
           splitMode: expenseFormValues.splitMode,
           recurrenceRule: expenseFormValues.recurrenceRule,
           recurringExpenseLink: getRecurringExpenseLinkUpdates(
@@ -1783,6 +1814,16 @@ export const friendsRouter = createTRPCRouter({
                   ),
               )
               .map((pf) => ({ expenseId: pf.expenseId, userId: pf.userId })),
+          },
+          // Sync ExpensePaidBy for direct expenses (single payer with full amount)
+          payers: {
+            deleteMany: {},
+            create: [
+              {
+                userId: expenseFormValues.paidBy[0].participant,
+                amount: expenseFormValues.amount,
+              },
+            ],
           },
           isReimbursement: expenseFormValues.isReimbursement,
           documents: {

--- a/src/trpc/routers/groups/balances/record-settlement.procedure.ts
+++ b/src/trpc/routers/groups/balances/record-settlement.procedure.ts
@@ -77,6 +77,9 @@ export const recordSettlementProcedure = protectedProcedure
               shares: 1,
             },
           },
+          payers: {
+            create: [{ userId: input.fromUserId, amount: input.amount }],
+          },
         },
       })
 


### PR DESCRIPTION
## Summary
- Add `ExpensePaidBy` (schema + migrations/backfill) so group expenses can have multiple payers; balances, stats, activity, import/export, and settlements credit each payer’s amount.
- Redesign Paid by as full-width Choice Cards (Single vs Evenly / Shares / Percentage / Amount), with digit-aware amount math and `singlePayerOnly` for friend/hybrid flows.
- Specs and backlog: `multi-payer-expenses` + next-up `paid-by-split-modes`.

## Test plan
- [ ] Apply migrations and confirm existing expenses backfill to one `ExpensePaidBy` row each
- [ ] Create/edit group expense with multiple payers; verify balances and detail/card labels
- [ ] Single-payer path still works (create, edit, reimbursement)
- [ ] Friend / hybrid floating create cannot add multiple payers
- [ ] Splitwise + Knots import of multi-payer rows; CSV/JSON export includes `paidBy`
- [ ] Activity log shows formatted payer changes (not raw JSON)
- [ ] `pnpm check-types` and relevant Jest suites pass